### PR TITLE
Peripheral/node host

### DIFF
--- a/src/api/java/org/squiddev/cctweaks/api/network/INetworkNodeHost.java
+++ b/src/api/java/org/squiddev/cctweaks/api/network/INetworkNodeHost.java
@@ -1,0 +1,17 @@
+package org.squiddev.cctweaks.api.network;
+
+/**
+ * An object that hosts a {@link INetworkNode}.
+ *
+ * Instead of implementing {@link INetworkNode} and delegating methods to it,
+ * you can implement this interface instead. This is supported for TileEntities, multiparts
+ * and on {@link dan200.computercraft.api.turtle.ITurtleUpgrade}
+ */
+public interface INetworkNodeHost {
+	/**
+	 * Get this host's node. This should NEVER be null.
+	 *
+	 * @return The node this object holds
+	 */
+	INetworkNode getNode();
+}

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralHost.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralHost.java
@@ -1,0 +1,20 @@
+package org.squiddev.cctweaks.api.peripheral;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+
+/**
+ * An object that hosts a {@link IPeripheral}.
+ *
+ * Instead of implementing {@link IPeripheral} and delegating methods to it,
+ * you can implement this interface instead. This is supported for TileEntities
+ * and multiparts.
+ */
+public interface IPeripheralHost {
+	/**
+	 * Get this host's peripheral
+	 *
+	 * @param side The side to get the peripheral from
+	 * @return The peripheral this object holds
+	 */
+	IPeripheral getPeripheral(int side);
+}

--- a/src/main/java/org/squiddev/cctweaks/blocks/BlockBase.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/BlockBase.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -51,6 +52,30 @@ public abstract class BlockBase<T extends TileBase> extends BlockContainer imple
 		super.breakBlock(world, x, y, z, block, damage);
 
 		if (tile != null) tile.postRemove();
+	}
+
+	@Override
+	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
+		TileBase tile = getTile(world, x, y, z);
+		return tile != null && tile.onActivated(player, side);
+	}
+
+	@Override
+	public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
+		super.onNeighborBlockChange(world, x, y, z, block);
+		if (world.isRemote) return;
+
+		TileBase tile = getTile(world, x, y, z);
+		if (tile != null) tile.onNeighborChanged();
+	}
+
+	@Override
+	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
+		super.onNeighborChange(world, x, y, z, tileX, tileY, tileZ);
+		if (world instanceof World && ((World) world).isRemote) return;
+
+		TileBase tile = getTile(world, x, y, z);
+		if (tile != null) tile.onNeighborChanged();
 	}
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/blocks/TileBase.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/TileBase.java
@@ -1,5 +1,6 @@
 package org.squiddev.cctweaks.blocks;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
@@ -86,5 +87,22 @@ public abstract class TileBase extends TileEntity implements IWorldPosition {
 	public void markForUpdate() {
 		markDirty();
 		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+	}
+
+	/**
+	 * Called when the block is activated
+	 *
+	 * @param player The player who triggered this
+	 * @param side   The side the block is activated on
+	 * @return If the event succeeded
+	 */
+	public boolean onActivated(EntityPlayer player, int side) {
+		return false;
+	}
+
+	/**
+	 * Called when a neighbor tile/block changed
+	 */
+	public void onNeighborChanged() {
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/blocks/debug/TileDebugPeripheral.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/debug/TileDebugPeripheral.java
@@ -4,22 +4,16 @@ import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.shared.peripheral.PeripheralType;
-import dan200.computercraft.shared.peripheral.common.IPeripheralTile;
 import net.minecraft.util.Facing;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
 import org.squiddev.cctweaks.blocks.TileBase;
 import org.squiddev.cctweaks.core.utils.DebugLogger;
 
 /**
  * A peripheral that logs events and prints what side it comes from
  */
-public class TileDebugPeripheral extends TileBase implements IPeripheralTile {
+public class TileDebugPeripheral extends TileBase implements IPeripheralHost {
 	private IPeripheral[] sides = new IPeripheral[6];
-
-	@Override
-	public PeripheralType getPeripheralType() {
-		return null;
-	}
 
 	@Override
 	public IPeripheral getPeripheral(int side) {
@@ -29,20 +23,6 @@ public class TileDebugPeripheral extends TileBase implements IPeripheralTile {
 
 	protected IPeripheral createPeripheral(int side) {
 		return new SidedPeripheral(side);
-	}
-
-	@Override
-	public String getLabel() {
-		return null;
-	}
-
-	@Override
-	public int getDirection() {
-		return 0;
-	}
-
-	@Override
-	public void setDirection(int paramInt) {
 	}
 
 	public static class SidedPeripheral implements IPeripheral {

--- a/src/main/java/org/squiddev/cctweaks/blocks/network/BlockNetworked.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/network/BlockNetworked.java
@@ -6,10 +6,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 import dan200.computercraft.shared.peripheral.PeripheralType;
 import dan200.computercraft.shared.peripheral.common.PeripheralItemFactory;
 import dan200.computercraft.shared.peripheral.modem.TileCable;
-import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -20,6 +18,7 @@ import net.minecraft.world.World;
 import org.squiddev.cctweaks.CCTweaks;
 import org.squiddev.cctweaks.blocks.BlockBase;
 import org.squiddev.cctweaks.blocks.IMultiBlock;
+import org.squiddev.cctweaks.blocks.TileBase;
 import org.squiddev.cctweaks.core.utils.DebugLogger;
 import org.squiddev.cctweaks.core.utils.Helpers;
 import org.squiddev.cctweaks.items.ItemMultiBlock;
@@ -30,7 +29,7 @@ import java.util.List;
 /**
  * A bridge between two networks so they can communicate with each other
  */
-public class BlockNetworked extends BlockBase<TileNetworked> implements IMultiBlock {
+public class BlockNetworked extends BlockBase<TileBase> implements IMultiBlock {
 	@SideOnly(Side.CLIENT)
 	public static IIcon bridgeIcon;
 	@SideOnly(Side.CLIENT)
@@ -39,7 +38,7 @@ public class BlockNetworked extends BlockBase<TileNetworked> implements IMultiBl
 	public static IIcon[] modemIcons;
 
 	public BlockNetworked() {
-		super("networkedBlock", TileNetworked.class);
+		super("networkedBlock", TileBase.class);
 	}
 
 	@Override
@@ -51,30 +50,6 @@ public class BlockNetworked extends BlockBase<TileNetworked> implements IMultiBl
 				return new TileNetworkedModem();
 		}
 		return null;
-	}
-
-	@Override
-	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
-		TileNetworked tile = getTile(world, x, y, z);
-		return tile != null && tile.onActivated(player, side);
-	}
-
-	@Override
-	public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
-		super.onNeighborBlockChange(world, x, y, z, block);
-		if (world.isRemote) return;
-
-		TileNetworked tile = getTile(world, x, y, z);
-		if (tile != null) tile.onNeighborChanged();
-	}
-
-	@Override
-	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
-		super.onNeighborChange(world, x, y, z, tileX, tileY, tileZ);
-		if (world instanceof World && ((World) world).isRemote) return;
-
-		TileNetworked tile = getTile(world, x, y, z);
-		if (tile != null) tile.onNeighborChanged();
 	}
 
 	@SuppressWarnings("unchecked")
@@ -131,7 +106,7 @@ public class BlockNetworked extends BlockBase<TileNetworked> implements IMultiBl
 		int meta = world.getBlockMetadata(x, y, z);
 		switch (meta) {
 			case 1: {
-				TileNetworked tile = getTile(world, x, y, z);
+				TileBase tile = getTile(world, x, y, z);
 				if (tile != null && tile instanceof TileNetworkedModem) {
 					return getModemIcon(((TileNetworkedModem) tile).modem.state);
 				}

--- a/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedModem.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedModem.java
@@ -1,8 +1,6 @@
 package org.squiddev.cctweaks.blocks.network;
 
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.shared.peripheral.PeripheralType;
-import dan200.computercraft.shared.peripheral.common.IPeripheralTile;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentTranslation;
@@ -10,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.squiddev.cctweaks.api.IWorldPosition;
 import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
 import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
 import org.squiddev.cctweaks.core.network.NetworkHelpers;
 import org.squiddev.cctweaks.core.network.modem.MultiPeripheralModem;
 
@@ -20,7 +19,7 @@ import java.util.Set;
 /**
  * A full block implementation of a modem
  */
-public class TileNetworkedModem extends TileNetworked implements IPeripheralTile {
+public class TileNetworkedModem extends TileNetworked implements IPeripheralHost {
 	public final MultiPeripheralModem modem = new MultiPeripheralModem() {
 		@Override
 		public IWorldPosition getPosition() {
@@ -159,26 +158,7 @@ public class TileNetworkedModem extends TileNetworked implements IPeripheralTile
 	}
 
 	@Override
-	public PeripheralType getPeripheralType() {
-		return PeripheralType.WiredModem;
-	}
-
-	@Override
 	public IPeripheral getPeripheral(int side) {
 		return modem.modem;
-	}
-
-	@Override
-	public String getLabel() {
-		return null;
-	}
-
-	@Override
-	public int getDirection() {
-		return 0;
-	}
-
-	@Override
-	public void setDirection(int direction) {
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedModem.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedModem.java
@@ -6,9 +6,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChatComponentTranslation;
 import org.apache.commons.lang3.StringUtils;
 import org.squiddev.cctweaks.api.IWorldPosition;
+import org.squiddev.cctweaks.api.network.INetworkNode;
+import org.squiddev.cctweaks.api.network.INetworkNodeHost;
 import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
-import org.squiddev.cctweaks.api.network.Packet;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
+import org.squiddev.cctweaks.blocks.TileBase;
 import org.squiddev.cctweaks.core.network.NetworkHelpers;
 import org.squiddev.cctweaks.core.network.modem.MultiPeripheralModem;
 
@@ -19,7 +21,7 @@ import java.util.Set;
 /**
  * A full block implementation of a modem
  */
-public class TileNetworkedModem extends TileNetworked implements IPeripheralHost {
+public class TileNetworkedModem extends TileBase implements IPeripheralHost, INetworkNodeHost {
 	public final MultiPeripheralModem modem = new MultiPeripheralModem() {
 		@Override
 		public IWorldPosition getPosition() {
@@ -39,9 +41,9 @@ public class TileNetworkedModem extends TileNetworked implements IPeripheralHost
 
 	@Override
 	public void onNeighborChanged() {
-		Map<String, IPeripheral> oldPeripherals = getConnectedPeripherals();
+		Map<String, IPeripheral> oldPeripherals = modem.getConnectedPeripherals();
 		if (modem.hasChanged()) {
-			Map<String, IPeripheral> newPeripherals = getConnectedPeripherals();
+			Map<String, IPeripheral> newPeripherals = modem.getConnectedPeripherals();
 			for (Map.Entry<String, IPeripheral> p : newPeripherals.entrySet()) {
 				IPeripheral newPeriph = p.getValue();
 				String newName = p.getKey();
@@ -138,27 +140,12 @@ public class TileNetworkedModem extends TileNetworked implements IPeripheralHost
 	}
 
 	@Override
-	public void receivePacket(Packet packet, int distanceTravelled) {
-		modem.receivePacket(packet, distanceTravelled);
-	}
-
-	@Override
-	public void networkInvalidated() {
-		modem.networkInvalidated();
-	}
-
-	@Override
-	public Map<String, IPeripheral> getConnectedPeripherals() {
-		return modem.getConnectedPeripherals();
-	}
-
-	@Override
-	public Object lock() {
-		return modem.lock();
-	}
-
-	@Override
 	public IPeripheral getPeripheral(int side) {
 		return modem.modem;
+	}
+
+	@Override
+	public INetworkNode getNode() {
+		return modem;
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedWirelessBridge.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedWirelessBridge.java
@@ -7,17 +7,20 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import org.squiddev.cctweaks.api.IDataCard;
 import org.squiddev.cctweaks.api.IWorldPosition;
-import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.network.INetworkNode;
+import org.squiddev.cctweaks.api.network.INetworkNodeHost;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
+import org.squiddev.cctweaks.blocks.TileBase;
 import org.squiddev.cctweaks.core.network.bridge.NetworkBinding;
 import org.squiddev.cctweaks.core.network.modem.BasicModem;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
  * Bind networks together
  */
-public class TileNetworkedWirelessBridge extends TileNetworked implements IPeripheralHost {
+public class TileNetworkedWirelessBridge extends TileBase implements IPeripheralHost, INetworkNodeHost {
 	protected final NetworkBinding binding = new NetworkBinding(this);
 	protected final BasicModem modem = new BasicModem() {
 		@Override
@@ -27,7 +30,12 @@ public class TileNetworkedWirelessBridge extends TileNetworked implements IPerip
 
 		@Override
 		public Map<String, IPeripheral> findConnectedPeripherals() {
-			return TileNetworkedWirelessBridge.this.getConnectedPeripherals();
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public Iterable<IWorldPosition> getExtraNodes() {
+			return binding.getPositions();
 		}
 	};
 
@@ -86,27 +94,12 @@ public class TileNetworkedWirelessBridge extends TileNetworked implements IPerip
 	}
 
 	@Override
-	public Iterable<IWorldPosition> getExtraNodes() {
-		return binding.getPositions();
-	}
-
-	@Override
-	public void receivePacket(Packet packet, int distanceTravelled) {
-		modem.receivePacket(packet, distanceTravelled);
-	}
-
-	@Override
-	public void networkInvalidated() {
-		modem.networkInvalidated();
-	}
-
-	@Override
-	public Object lock() {
-		return modem.lock();
-	}
-
-	@Override
 	public IPeripheral getPeripheral(int side) {
 		return modem.modem;
+	}
+
+	@Override
+	public INetworkNode getNode() {
+		return modem;
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedWirelessBridge.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/network/TileNetworkedWirelessBridge.java
@@ -1,8 +1,6 @@
 package org.squiddev.cctweaks.blocks.network;
 
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.shared.peripheral.PeripheralType;
-import dan200.computercraft.shared.peripheral.common.IPeripheralTile;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -10,6 +8,7 @@ import net.minecraft.world.World;
 import org.squiddev.cctweaks.api.IDataCard;
 import org.squiddev.cctweaks.api.IWorldPosition;
 import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
 import org.squiddev.cctweaks.core.network.bridge.NetworkBinding;
 import org.squiddev.cctweaks.core.network.modem.BasicModem;
 
@@ -18,7 +17,7 @@ import java.util.Map;
 /**
  * Bind networks together
  */
-public class TileNetworkedWirelessBridge extends TileNetworked implements IPeripheralTile {
+public class TileNetworkedWirelessBridge extends TileNetworked implements IPeripheralHost {
 	protected final NetworkBinding binding = new NetworkBinding(this);
 	protected final BasicModem modem = new BasicModem() {
 		@Override
@@ -107,26 +106,7 @@ public class TileNetworkedWirelessBridge extends TileNetworked implements IPerip
 	}
 
 	@Override
-	public PeripheralType getPeripheralType() {
-		return PeripheralType.WiredModem;
-	}
-
-	@Override
 	public IPeripheral getPeripheral(int side) {
 		return modem.modem;
-	}
-
-	@Override
-	public String getLabel() {
-		return null;
-	}
-
-	@Override
-	public int getDirection() {
-		return 0;
-	}
-
-	@Override
-	public void setDirection(int direction) {
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/core/network/NetworkRegistry.java
+++ b/src/main/java/org/squiddev/cctweaks/core/network/NetworkRegistry.java
@@ -4,6 +4,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockAccess;
 import org.squiddev.cctweaks.api.IWorldPosition;
 import org.squiddev.cctweaks.api.network.INetworkNode;
+import org.squiddev.cctweaks.api.network.INetworkNodeHost;
 import org.squiddev.cctweaks.api.network.INetworkNodeProvider;
 import org.squiddev.cctweaks.api.network.INetworkRegistry;
 import org.squiddev.cctweaks.core.utils.DebugLogger;
@@ -30,7 +31,8 @@ public final class NetworkRegistry implements INetworkRegistry {
 	public boolean isNode(TileEntity tile) {
 		if (tile == null) return false;
 
-		if (tile instanceof INetworkNode) return true;
+		if (tile instanceof INetworkNode || tile instanceof INetworkNodeHost) return true;
+
 		for (INetworkNodeProvider provider : providers) {
 			try {
 				if (provider.isNode(tile)) return true;
@@ -57,9 +59,8 @@ public final class NetworkRegistry implements INetworkRegistry {
 	public INetworkNode getNode(TileEntity tile) {
 		if (tile == null) return null;
 
-		if (tile instanceof INetworkNode) {
-			return (INetworkNode) tile;
-		}
+		if (tile instanceof INetworkNode) return (INetworkNode) tile;
+		if (tile instanceof INetworkNodeHost) return ((INetworkNodeHost) tile).getNode();
 
 		for (INetworkNodeProvider provider : providers) {
 			try {

--- a/src/main/java/org/squiddev/cctweaks/core/network/modem/BasicModemPeripheral.java
+++ b/src/main/java/org/squiddev/cctweaks/core/network/modem/BasicModemPeripheral.java
@@ -7,10 +7,9 @@ import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.shared.peripheral.modem.INetwork;
 import dan200.computercraft.shared.peripheral.modem.ModemPeripheral;
 import net.minecraft.util.Vec3;
-import net.minecraftforge.common.util.ForgeDirection;
 import org.squiddev.cctweaks.api.IWorldPosition;
 import org.squiddev.cctweaks.api.network.INetworkNode;
-import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.network.INetworkNodeHost;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +19,7 @@ import java.util.Map;
  *
  * @see BasicModem
  */
-public class BasicModemPeripheral<T extends BasicModem> extends ModemPeripheral implements INetworkNode {
+public class BasicModemPeripheral<T extends BasicModem> extends ModemPeripheral implements INetworkNodeHost {
 	public final T modem;
 
 	public BasicModemPeripheral(T modem) {
@@ -146,37 +145,7 @@ public class BasicModemPeripheral<T extends BasicModem> extends ModemPeripheral 
 	}
 
 	@Override
-	public boolean canBeVisited(ForgeDirection from) {
-		return modem.canBeVisited(from);
-	}
-
-	@Override
-	public boolean canVisitTo(ForgeDirection to) {
-		return modem.canVisitTo(to);
-	}
-
-	@Override
-	public Map<String, IPeripheral> getConnectedPeripherals() {
-		return modem.getConnectedPeripherals();
-	}
-
-	@Override
-	public void receivePacket(Packet packet, int distanceTravelled) {
-		modem.receivePacket(packet, distanceTravelled);
-	}
-
-	@Override
-	public void networkInvalidated() {
-		modem.networkInvalidated();
-	}
-
-	@Override
-	public Iterable<IWorldPosition> getExtraNodes() {
-		return modem.getExtraNodes();
-	}
-
-	@Override
-	public Object lock() {
-		return modem.lock();
+	public INetworkNode getNode() {
+		return modem;
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/core/network/modem/MultiPeripheralModem.java
+++ b/src/main/java/org/squiddev/cctweaks/core/network/modem/MultiPeripheralModem.java
@@ -2,7 +2,6 @@ package org.squiddev.cctweaks.core.network.modem;
 
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.shared.peripheral.modem.ModemPeripheral;
 import dan200.computercraft.shared.util.IDAssigner;
 import dan200.computercraft.shared.util.PeripheralUtil;
 import net.minecraft.util.Facing;
@@ -76,7 +75,7 @@ public abstract class MultiPeripheralModem extends BasicModem {
 				Facing.oppositeSide[dir]
 			);
 
-			if (peripheral == null || peripheral instanceof ModemPeripheral) {
+			if (peripheral == null || (peripheral instanceof BasicModemPeripheral && ((BasicModemPeripheral) peripheral).modem instanceof MultiPeripheralModem)) {
 				ids[dir] = -1;
 				peripherals[dir] = null;
 			} else if (ids[dir] <= -1) {

--- a/src/main/java/org/squiddev/cctweaks/core/patch/TileCable_Patch.java
+++ b/src/main/java/org/squiddev/cctweaks/core/patch/TileCable_Patch.java
@@ -113,13 +113,17 @@ public class TileCable_Patch extends TileCable implements INetworkNode, INetwork
 
 	@Override
 	public boolean canBeVisited(ForgeDirection from) {
-		// Can't be visited by other nodes if it is destroyed or has no cable
-		return !m_destroyed && getPeripheralType() != PeripheralType.WiredModem;
+		// Can't be visited by other nodes if it is destroyed
+		if (m_destroyed) return false;
+
+		// Or has no cable or is the side it is facing
+		PeripheralType type = getPeripheralType();
+		return type == PeripheralType.Cable || (type == PeripheralType.WiredModemWithCable && from.ordinal() != getDirection());
 	}
 
 	@Override
 	public boolean canVisitTo(ForgeDirection to) {
-		return !m_destroyed && getPeripheralType() != PeripheralType.WiredModem;
+		return canBeVisited(to);
 	}
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHostProvider.java
+++ b/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHostProvider.java
@@ -1,0 +1,37 @@
+package org.squiddev.cctweaks.core.peripheral;
+
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
+import org.squiddev.cctweaks.core.registry.IModule;
+
+/**
+ * Adds support for {@link org.squiddev.cctweaks.api.peripheral.IPeripheralHost}
+ */
+public class PeripheralHostProvider implements IModule, IPeripheralProvider {
+	@Override
+	public boolean canLoad() {
+		return true;
+	}
+
+	@Override
+	public void preInit() {
+	}
+
+	@Override
+	public void init() {
+		ComputerCraftAPI.registerPeripheralProvider(this);
+	}
+
+	@Override
+	public IPeripheral getPeripheral(World world, int x, int y, int z, int side) {
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof IPeripheralHost) {
+			return ((IPeripheralHost) tile).getPeripheral(side);
+		}
+		return null;
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/registry/Registry.java
+++ b/src/main/java/org/squiddev/cctweaks/core/registry/Registry.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import org.squiddev.cctweaks.blocks.debug.BlockDebug;
 import org.squiddev.cctweaks.blocks.network.BlockNetworked;
+import org.squiddev.cctweaks.core.peripheral.PeripheralHostProvider;
 import org.squiddev.cctweaks.core.turtle.DefaultTurtleProviders;
 import org.squiddev.cctweaks.integration.IndustrialCraftIntegration;
 import org.squiddev.cctweaks.integration.RedstoneFluxIntegration;
@@ -42,6 +43,8 @@ public final class Registry {
 
 		addModule(new MultipartIntegration());
 
+		addModule(new PeripheralHostProvider());
+
 		addModule(new DefaultTurtleProviders());
 		addModule(new TurtleUpgradeWirelessBridge());
 		addModule(new RedstoneFluxIntegration());
@@ -63,7 +66,7 @@ public final class Registry {
 
 
 	public static void preInit() {
-		if(preInit) throw new IllegalStateException("Attempting to preInit twice");
+		if (preInit) throw new IllegalStateException("Attempting to preInit twice");
 		preInit = true;
 		for (IModule module : modules) {
 			if (module.canLoad()) module.preInit();
@@ -71,8 +74,8 @@ public final class Registry {
 	}
 
 	public static void init() {
-		if(!preInit) throw new IllegalStateException("Cannot init before preInit");
-		if(init) throw new IllegalStateException("Attempting to init twice");
+		if (!preInit) throw new IllegalStateException("Cannot init before preInit");
+		if (init) throw new IllegalStateException("Attempting to init twice");
 
 		init = true;
 		for (IModule module : modules) {

--- a/src/main/java/org/squiddev/cctweaks/core/turtle/DefaultTurtleProviders.java
+++ b/src/main/java/org/squiddev/cctweaks/core/turtle/DefaultTurtleProviders.java
@@ -11,6 +11,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityFurnace;
 import org.squiddev.cctweaks.api.CCTweaksAPI;
 import org.squiddev.cctweaks.api.network.INetworkNode;
+import org.squiddev.cctweaks.api.network.INetworkNodeHost;
 import org.squiddev.cctweaks.api.network.INetworkNodeProvider;
 import org.squiddev.cctweaks.api.network.NetworkAPI;
 import org.squiddev.cctweaks.api.turtle.ITurtleFuelProvider;
@@ -78,10 +79,16 @@ public class DefaultTurtleProviders implements IModule {
 
 			public INetworkNode getNode(ITurtleAccess turtle, TurtleSide side) {
 				ITurtleUpgrade upgrade = turtle.getUpgrade(side);
-				if (upgrade != null && upgrade instanceof INetworkNode) return (INetworkNode) upgrade;
+				if (upgrade != null) {
+					if (upgrade instanceof INetworkNode) return (INetworkNode) upgrade;
+					if (upgrade instanceof INetworkNodeHost) return ((INetworkNodeHost) upgrade).getNode();
+				}
 
 				IPeripheral peripheral = turtle.getPeripheral(side);
-				if (peripheral != null && peripheral instanceof INetworkNode) return (INetworkNode) peripheral;
+				if (peripheral != null) {
+					if (peripheral instanceof INetworkNode) return (INetworkNode) peripheral;
+					if (peripheral instanceof INetworkNodeHost) return ((INetworkNodeHost) peripheral).getNode();
+				}
 
 				return null;
 			}

--- a/src/main/java/org/squiddev/cctweaks/core/utils/DebugLogger.java
+++ b/src/main/java/org/squiddev/cctweaks/core/utils/DebugLogger.java
@@ -1,5 +1,6 @@
 package org.squiddev.cctweaks.core.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
@@ -12,6 +13,14 @@ import org.squiddev.cctweaks.core.Config;
  */
 public class DebugLogger {
 	private static final Logger logger = LogManager.getLogger(CCTweaks.ID);
+
+	public static void trace(String message) {
+		try {
+			throw new RuntimeException();
+		} catch (RuntimeException e) {
+			debug(message + "\n\tat " + StringUtils.join(Thread.currentThread().getStackTrace(), "\n\tat "));
+		}
+	}
 
 	public static void debug(Marker marker, String message) {
 		if (Config.config.debug) {

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/MultipartIntegration.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/MultipartIntegration.java
@@ -7,7 +7,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.api.peripheral.IPeripheralProvider;
-import dan200.computercraft.shared.peripheral.common.IPeripheralTile;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
@@ -15,6 +14,7 @@ import net.minecraftforge.client.MinecraftForgeClient;
 import org.squiddev.cctweaks.api.network.INetworkNode;
 import org.squiddev.cctweaks.api.network.INetworkNodeProvider;
 import org.squiddev.cctweaks.api.network.NetworkAPI;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
 import org.squiddev.cctweaks.core.registry.IClientModule;
 import org.squiddev.cctweaks.core.registry.Registry;
 import org.squiddev.cctweaks.core.utils.Helpers;
@@ -52,7 +52,7 @@ public class MultipartIntegration extends ModIntegration implements IClientModul
 					// Cables reside in the central slot so we can just fetch that
 					// instead and use the cable to delegate to other nodes in the multipart
 					TMultiPart part = ((TileMultipart) tile).partMap(6);
-					if (part != null && part instanceof INetworkNode) {
+					if (part != null) {
 						return (INetworkNode) part;
 					}
 				}
@@ -77,8 +77,8 @@ public class MultipartIntegration extends ModIntegration implements IClientModul
 					if (part != null) {
 						if (part instanceof IPeripheral) {
 							return (IPeripheral) part;
-						} else if (part instanceof IPeripheralTile) {
-							return ((IPeripheralTile) part).getPeripheral(side);
+						} else if (part instanceof IPeripheralHost) {
+							return ((IPeripheralHost) part).getPeripheral(side);
 						}
 					}
 				}

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/MultipartIntegration.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/MultipartIntegration.java
@@ -12,6 +12,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.client.MinecraftForgeClient;
 import org.squiddev.cctweaks.api.network.INetworkNode;
+import org.squiddev.cctweaks.api.network.INetworkNodeHost;
 import org.squiddev.cctweaks.api.network.INetworkNodeProvider;
 import org.squiddev.cctweaks.api.network.NetworkAPI;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
@@ -53,7 +54,8 @@ public class MultipartIntegration extends ModIntegration implements IClientModul
 					// instead and use the cable to delegate to other nodes in the multipart
 					TMultiPart part = ((TileMultipart) tile).partMap(6);
 					if (part != null) {
-						return (INetworkNode) part;
+						if (part instanceof INetworkNode) return (INetworkNode) part;
+						if (part instanceof INetworkNodeHost) return ((INetworkNodeHost) part).getNode();
 					}
 				}
 

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
@@ -213,12 +213,12 @@ public class PartModem extends PartSidedNetwork implements IPeripheralHost {
 
 	@Override
 	public boolean canBeVisited(ForgeDirection from) {
-		return from.getOpposite().ordinal() != direction;
+		return from.ordinal() != direction;
 	}
 
 	@Override
 	public boolean canVisitTo(ForgeDirection to) {
-		return to.ordinal() != direction;
+		return canBeVisited(to);
 	}
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
@@ -12,7 +12,6 @@ import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.client.render.FixedRenderBlocks;
 import dan200.computercraft.shared.peripheral.PeripheralType;
-import dan200.computercraft.shared.peripheral.common.IPeripheralTile;
 import dan200.computercraft.shared.peripheral.common.PeripheralItemFactory;
 import dan200.computercraft.shared.peripheral.modem.ModemPeripheral;
 import dan200.computercraft.shared.peripheral.modem.TileCable;
@@ -32,6 +31,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.squiddev.cctweaks.CCTweaks;
 import org.squiddev.cctweaks.api.IWorldPosition;
 import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
 import org.squiddev.cctweaks.core.network.NetworkHelpers;
 import org.squiddev.cctweaks.core.network.modem.SinglePeripheralModem;
 import org.squiddev.cctweaks.core.utils.ComputerAccessor;
@@ -41,7 +41,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Map;
 
-public class PartModem extends PartSidedNetwork implements IPeripheralTile {
+public class PartModem extends PartSidedNetwork implements IPeripheralHost {
 	@SideOnly(Side.CLIENT)
 	private static IIcon[] icons;
 
@@ -243,27 +243,8 @@ public class PartModem extends PartSidedNetwork implements IPeripheralTile {
 	}
 
 	@Override
-	public int getDirection() {
-		return direction;
-	}
-
-	@Override
-	public void setDirection(int direction) {
-	}
-
-	@Override
-	public PeripheralType getPeripheralType() {
-		return PeripheralType.WiredModem;
-	}
-
-	@Override
 	public IPeripheral getPeripheral(int side) {
 		if (side == direction) return modem.modem;
-		return null;
-	}
-
-	@Override
-	public String getLabel() {
 		return null;
 	}
 

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
@@ -13,7 +13,6 @@ import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.client.render.FixedRenderBlocks;
 import dan200.computercraft.shared.peripheral.PeripheralType;
 import dan200.computercraft.shared.peripheral.common.PeripheralItemFactory;
-import dan200.computercraft.shared.peripheral.modem.ModemPeripheral;
 import dan200.computercraft.shared.peripheral.modem.TileCable;
 import dan200.computercraft.shared.util.IDAssigner;
 import dan200.computercraft.shared.util.PeripheralUtil;
@@ -310,7 +309,7 @@ public class PartModem extends PartSidedNetwork implements IPeripheralHost {
 			int z = z() + Facing.offsetsZForSide[dir];
 			IPeripheral peripheral = PeripheralUtil.getPeripheral(world(), x, y, z, Facing.oppositeSide[dir]);
 
-			if (peripheral == null || peripheral instanceof ModemPeripheral) {
+			if (peripheral == null) {
 				id = -1;
 				peripheral = null;
 			} else if (id <= -1) {

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModem.java
@@ -26,7 +26,6 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
 import org.squiddev.cctweaks.CCTweaks;
 import org.squiddev.cctweaks.api.IWorldPosition;
 import org.squiddev.cctweaks.api.network.Packet;
@@ -209,16 +208,6 @@ public class PartModem extends PartSidedNetwork implements IPeripheralHost {
 		direction = tag.getByte("modem_direction");
 		modem.setState(tag.getBoolean("modem_enabled") ? WiredModem.MODEM_PERIPHERAL : 0);
 		modem.id = tag.getInteger("modem_id");
-	}
-
-	@Override
-	public boolean canBeVisited(ForgeDirection from) {
-		return from.ordinal() != direction;
-	}
-
-	@Override
-	public boolean canVisitTo(ForgeDirection to) {
-		return canBeVisited(to);
 	}
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModemWithCableIntermediate.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartModemWithCableIntermediate.java
@@ -12,7 +12,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.shared.peripheral.PeripheralType;
-import dan200.computercraft.shared.peripheral.common.IPeripheralTile;
 import dan200.computercraft.shared.peripheral.common.PeripheralItemFactory;
 import dan200.computercraft.shared.peripheral.modem.TileCable;
 import net.minecraft.item.ItemStack;
@@ -20,12 +19,13 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import org.squiddev.cctweaks.CCTweaks;
 import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class PartModemWithCableIntermediate extends PartCable implements IPeripheralTile {
+public class PartModemWithCableIntermediate extends PartCable implements IPeripheralHost {
 	public static final String NAME = CCTweaks.NAME + ":networkModemCable";
 
 	private final PartModem modem;
@@ -159,27 +159,7 @@ public class PartModemWithCableIntermediate extends PartCable implements IPeriph
 	}
 
 	@Override
-	public PeripheralType getPeripheralType() {
-		return modem.getPeripheralType();
-	}
-
-	@Override
 	public IPeripheral getPeripheral(int side) {
 		return modem.getPeripheral(side);
-	}
-
-	@Override
-	public String getLabel() {
-		return modem.getLabel();
-	}
-
-	@Override
-	public int getDirection() {
-		return modem.getDirection();
-	}
-
-	@Override
-	public void setDirection(int direction) {
-		modem.setDirection(direction);
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartSidedNetwork.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/multipart/network/PartSidedNetwork.java
@@ -71,12 +71,12 @@ public abstract class PartSidedNetwork extends PartBase implements INetworkNode,
 
 	@Override
 	public boolean canBeVisited(ForgeDirection from) {
-		return true;
+		return from.ordinal() != direction;
 	}
 
 	@Override
 	public boolean canVisitTo(ForgeDirection to) {
-		return true;
+		return canBeVisited(to);
 	}
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/items/ItemComputerAction.java
+++ b/src/main/java/org/squiddev/cctweaks/items/ItemComputerAction.java
@@ -22,18 +22,18 @@ public abstract class ItemComputerAction extends ItemBase {
 		}
 
 		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile == null) return false;
 
-		// Ensure tile is Computer Tile
-		if (tile == null || !(tile instanceof TileComputerBase)) {
-			return false;
-		}
-
-		// Allow custom Turtle Actions
-		boolean result = false;
-		if (tile instanceof TileTurtle) {
-			result = upgradeTurtle(stack, player, world, x, y, z, (TileTurtle) tile);
+		boolean result;
+		if (tile instanceof TileComputerBase) {
+			// Allow custom Turtle Actions
+			if (tile instanceof TileTurtle) {
+				result = upgradeTurtle(stack, player, (TileTurtle) tile, side);
+			} else {
+				result = upgradeComputer(stack, player, (TileComputerBase) tile, side);
+			}
 		} else {
-			result = upgradeComputer(stack, player, world, x, y, z, (TileComputerBase) tile);
+			result = itemUse(stack, player, tile, side);
 		}
 
 		if (result) {
@@ -45,9 +45,16 @@ public abstract class ItemComputerAction extends ItemBase {
 		return result;
 	}
 
-	protected abstract boolean upgradeComputer(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, TileComputerBase computerTile);
+	protected abstract boolean upgradeComputer(ItemStack stack, EntityPlayer player, TileComputerBase computerTile, int side);
 
-	protected boolean upgradeTurtle(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, TileTurtle computerTile) {
-		return upgradeComputer(stack, player, world, x, y, z, computerTile);
+	protected boolean upgradeTurtle(ItemStack stack, EntityPlayer player, TileTurtle computerTile, int side) {
+		return upgradeComputer(stack, player, computerTile, side);
+	}
+
+	/**
+	 * Custom action on other tile types
+	 */
+	protected boolean itemUse(ItemStack stack, EntityPlayer player, TileEntity tile, int side) {
+		return false;
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/items/ItemComputerUpgrade.java
+++ b/src/main/java/org/squiddev/cctweaks/items/ItemComputerUpgrade.java
@@ -33,7 +33,11 @@ public class ItemComputerUpgrade extends ItemComputerAction {
 		super("computerUpgrade");
 	}
 
-	protected boolean upgradeComputer(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, TileComputerBase computerTile) {
+	@Override
+	protected boolean upgradeComputer(ItemStack stack, EntityPlayer player, TileComputerBase computerTile, int side) {
+		int x = computerTile.xCoord, y = computerTile.yCoord, z = computerTile.zCoord;
+		World world = computerTile.getWorldObj();
+
 		// Check we can copy the tile and it is a normal computer
 		if (computerTile.getFamily() != ComputerFamily.Normal || ComputerAccessor.tileCopy == null) {
 			return false;
@@ -65,7 +69,11 @@ public class ItemComputerUpgrade extends ItemComputerAction {
 		return true;
 	}
 
-	protected boolean upgradeTurtle(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, TileTurtle computerTile) {
+	@Override
+	protected boolean upgradeTurtle(ItemStack stack, EntityPlayer player, TileTurtle computerTile, int side) {
+		int x = computerTile.xCoord, y = computerTile.yCoord, z = computerTile.zCoord;
+		World world = computerTile.getWorldObj();
+
 		// Ensure it is a normal computer
 		if (computerTile.getFamily() != ComputerFamily.Normal) {
 			return false;

--- a/src/main/java/org/squiddev/cctweaks/items/ItemDebugger.java
+++ b/src/main/java/org/squiddev/cctweaks/items/ItemDebugger.java
@@ -1,25 +1,40 @@
 package org.squiddev.cctweaks.items;
 
+import dan200.computercraft.api.peripheral.IPeripheral;
 import dan200.computercraft.core.lua.LuaJLuaMachine;
 import dan200.computercraft.shared.computer.blocks.TileComputerBase;
 import dan200.computercraft.shared.computer.core.ServerComputer;
+import dan200.computercraft.shared.util.PeripheralUtil;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.world.World;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatStyle;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
+import org.apache.commons.lang3.StringUtils;
 import org.luaj.vm2.LuaValue;
 import org.luaj.vm2.lib.DebugLib;
+import org.squiddev.cctweaks.api.network.INetworkAccess;
+import org.squiddev.cctweaks.api.network.INetworkNode;
+import org.squiddev.cctweaks.api.network.NetworkAPI;
 import org.squiddev.cctweaks.core.Config;
+import org.squiddev.cctweaks.core.network.modem.BasicModemPeripheral;
 import org.squiddev.cctweaks.core.utils.ComputerAccessor;
 import org.squiddev.cctweaks.core.utils.DebugLogger;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class ItemDebugger extends ItemComputerAction {
 	public ItemDebugger() {
 		super("debugger");
 	}
 
-	protected boolean upgradeComputer(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, TileComputerBase computerTile) {
+	@Override
+	protected boolean upgradeComputer(ItemStack stack, EntityPlayer player, TileComputerBase computerTile, int side) {
 		ServerComputer serverComputer = computerTile.getServerComputer();
-
 		if (serverComputer == null) return false;
 
 		try {
@@ -49,7 +64,59 @@ public class ItemDebugger extends ItemComputerAction {
 	}
 
 	@Override
+	protected boolean itemUse(ItemStack stack, EntityPlayer player, TileEntity tile, int side) {
+		Set<String> locals = new HashSet<String>();
+		Set<String> remotes = new HashSet<String>();
+		IPeripheral peripheral;
+
+		INetworkNode node = NetworkAPI.registry().getNode(tile);
+		if (node != null) {
+			Map<String, IPeripheral> p = node.getConnectedPeripherals();
+			if (p != null) locals.addAll(p.keySet());
+		}
+
+		peripheral = PeripheralUtil.getPeripheral(tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord, side);
+		if (peripheral != null) {
+			if (peripheral instanceof BasicModemPeripheral) {
+				Map<String, IPeripheral> p = ((BasicModemPeripheral) peripheral).modem.peripheralsByName();
+				if (p != null) remotes.addAll(p.keySet());
+			}
+		}
+
+		if (tile instanceof INetworkAccess) {
+			Map<String, IPeripheral> p = ((INetworkAccess) tile).peripheralsByName();
+			if (p != null) remotes.addAll(p.keySet());
+		}
+
+		if (peripheral != null || !locals.isEmpty() || !remotes.isEmpty()) {
+			player.addChatComponentMessage(
+				new ChatComponentText("Tile: " + tile.getClass().getSimpleName() + ": " + tile.getBlockType().getLocalizedName())
+					.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.LIGHT_PURPLE))
+			);
+
+			if (peripheral != null) player.addChatMessage(headerChat("Peripheral", peripheral.getType()));
+			if (!locals.isEmpty()) player.addChatMessage(headerChat("Locals", locals));
+			if (!remotes.isEmpty()) player.addChatMessage(headerChat("Remotes", remotes));
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean canLoad() {
 		return Config.config.enableDebugWand;
+	}
+
+	public static IChatComponent headerChat(String header, String message) {
+		return new ChatComponentText(header + ": ")
+			.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.AQUA))
+			.appendSibling(new ChatComponentText(message)
+					.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.GRAY).setItalic(true))
+			);
+	}
+
+	public static IChatComponent headerChat(String header, Iterable<String> message) {
+		return headerChat(header, StringUtils.join(message, ", "));
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/items/ItemDebugger.java
+++ b/src/main/java/org/squiddev/cctweaks/items/ItemDebugger.java
@@ -88,7 +88,7 @@ public class ItemDebugger extends ItemComputerAction {
 			if (p != null) remotes.addAll(p.keySet());
 		}
 
-		if (peripheral != null || !locals.isEmpty() || !remotes.isEmpty()) {
+		if (node != null || peripheral != null || !locals.isEmpty() || !remotes.isEmpty()) {
 			player.addChatComponentMessage(
 				new ChatComponentText("Tile: " + tile.getClass().getSimpleName() + ": " + tile.getBlockType().getLocalizedName())
 					.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.LIGHT_PURPLE))


### PR DESCRIPTION
Adds `IPeripheralHost` and `INodeHost` interfaces to enable delegating to other network nodes.