### PR TITLE
OpenPeripheral Integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ mod_version=0.2-pr1
 #########################################################
 api_ic2_version=2.+
 api_rf_version=2
+op_version=3.2

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -19,6 +19,11 @@ repositories {
 		url "http://maven.ic2.player.to"
 	}
 
+	maven {
+		name "OpenMods"
+		url "http://repo.openmods.info/artifactory/openmods"
+	}
+
 	ivy {
 		name = "ComputerCraft"
 		artifactPattern "http://addons-origin.cursecdn.com/files/2228/723/[module][revision].[ext]"
@@ -45,6 +50,7 @@ dependencies {
 
 	compile "CoFHLib:CoFHLib:[${project.mc_version}]${project.cofhlib_version}-dev:jar"
 	compile "net.industrial-craft:industrialcraft-2:${project.api_ic2_version}:api"
+	compile "openperipheral:OpenPeripheralCore-API:${project.op_version}"
 
 	fatPackage(group: 'org.squiddev', name: 'luaj.luajc', version: '1.+') {
 		// We provide a custom LuaJ source with ComputerCraft

--- a/src/api/java/org/squiddev/cctweaks/api/ICCTweaksAPI.java
+++ b/src/api/java/org/squiddev/cctweaks/api/ICCTweaksAPI.java
@@ -2,6 +2,7 @@ package org.squiddev.cctweaks.api;
 
 import org.squiddev.cctweaks.api.network.INetworkRegistry;
 import org.squiddev.cctweaks.api.network.INetworkVisitor;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHelpers;
 import org.squiddev.cctweaks.api.turtle.ITurtleFuelRegistry;
 
 /**
@@ -13,4 +14,6 @@ public interface ICCTweaksAPI {
 	INetworkRegistry networkRegistry();
 
 	ITurtleFuelRegistry fuelRegistry();
+
+	IPeripheralHelpers peripheralHelpers();
 }

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/INetworkedAdapter.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/INetworkedAdapter.java
@@ -1,0 +1,20 @@
+package org.squiddev.cctweaks.api.peripheral;
+
+import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
+
+/**
+ * An extension class to {@code openperipheral.api.adapter.IAdapter}
+ *
+ * Requires OpenPeripheral to function.
+ * This will provide the same methods as {@link INetworkedPeripheral}
+ */
+public interface INetworkedAdapter extends INetworkedPeripheral {
+	/**
+	 * Environment variable (see {@code openperipheral.api.adapter.method.Env})
+	 * for the network this is connected to.
+	 *
+	 * This is an instance of {@link org.squiddev.cctweaks.api.network.INetworkAccess} that
+	 * delegates to all connected networks.
+	 */
+	String ARG_NETWORK = "cctweaks.networkAccess";
+}

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralEnvironments.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralEnvironments.java
@@ -3,14 +3,13 @@ package org.squiddev.cctweaks.api.peripheral;
 import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
 
 /**
- * Various environments that can be used with
- * {@link openperipheral.api.adapter.method.Env}
+ * Various environments that can be used with openperipheral.api.adapter.method.Env
  *
  * Requires OpenPeripheral to function.
  */
 public interface IPeripheralEnvironments extends INetworkedPeripheral {
 	/**
-	 * Environment variable (see {@code openperipheral.api.adapter.method.Env})
+	 * Environment variable (see openperipheral.api.adapter.method.Env)
 	 * for the network this is connected to.
 	 *
 	 * This is an instance of {@link org.squiddev.cctweaks.api.network.INetworkAccess} that

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralEnvironments.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralEnvironments.java
@@ -3,12 +3,12 @@ package org.squiddev.cctweaks.api.peripheral;
 import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
 
 /**
- * An extension class to {@code openperipheral.api.adapter.IAdapter}
+ * Various environments that can be used with
+ * {@link openperipheral.api.adapter.method.Env}
  *
  * Requires OpenPeripheral to function.
- * This will provide the same methods as {@link INetworkedPeripheral}
  */
-public interface INetworkedAdapter extends INetworkedPeripheral {
+public interface IPeripheralEnvironments extends INetworkedPeripheral {
 	/**
 	 * Environment variable (see {@code openperipheral.api.adapter.method.Env})
 	 * for the network this is connected to.

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralHelpers.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralHelpers.java
@@ -1,0 +1,16 @@
+package org.squiddev.cctweaks.api.peripheral;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+
+/**
+ * Useful helpers for peripherals
+ */
+public interface IPeripheralHelpers {
+	/**
+	 * Get the base peripheral by following a chain of {@link IPeripheralProxy}s.
+	 *
+	 * @param peripheral The peripheral
+	 * @return The base peripheral
+	 */
+	IPeripheral getBasePeripheral(IPeripheral peripheral);
+}

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralHelpers.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralHelpers.java
@@ -13,4 +13,15 @@ public interface IPeripheralHelpers {
 	 * @return The base peripheral
 	 */
 	IPeripheral getBasePeripheral(IPeripheral peripheral);
+
+	/**
+	 * Gets the target peripheral for this peripheral.
+	 *
+	 * If it does not implement {@link IPeripheralTargeted} then it will attempt to find
+	 * the parent peripheral using {@link IPeripheralProxy} and start the search again.
+	 *
+	 * @param peripheral The peripheral to find
+	 * @return The target or the last peripheral we found
+	 */
+	Object getTarget(IPeripheral peripheral);
 }

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralProxy.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralProxy.java
@@ -9,10 +9,11 @@ import dan200.computercraft.api.peripheral.IPeripheral;
  * this is simply a method of getting the base peripheral if additional
  * processing needs to occur on that instead.
  *
- * You should also implement {@link org.squiddev.cctweaks.api.network.INetworkedPeripheral}
- * should you wish to delegate network events too.
+ * You should always implement {@link IPeripheral}.
+ * You should implement {@link org.squiddev.cctweaks.api.network.INetworkedPeripheral}
+ * if you wish to delegate network events.
  */
-public interface IPeripheralProxy extends IPeripheral {
+public interface IPeripheralProxy {
 	/**
 	 * Get the base peripheral for this peripheral
 	 *

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralProxy.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralProxy.java
@@ -1,0 +1,22 @@
+package org.squiddev.cctweaks.api.peripheral;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+
+/**
+ * Used to denote a peripheral that delegates to another peripheral.
+ *
+ * This does not automatically delegate, use {@link IPeripheralHost} for that,
+ * this is simply a method of getting the base peripheral if additional
+ * processing needs to occur on that instead.
+ *
+ * You should also implement {@link org.squiddev.cctweaks.api.network.INetworkedPeripheral}
+ * should you wish to delegate network events too.
+ */
+public interface IPeripheralProxy extends IPeripheral {
+	/**
+	 * Get the base peripheral for this peripheral
+	 *
+	 * @return The peripheral this delegates to
+	 */
+	IPeripheral getBasePeripheral();
+}

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralTargeted.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralTargeted.java
@@ -1,15 +1,12 @@
 package org.squiddev.cctweaks.api.peripheral;
 
-import dan200.computercraft.api.peripheral.IPeripheral;
-
 /**
  * Used to denote a peripheral that targets a TileEntity or other object in game
  *
  * This can be used from the Java side to access additional methods. We inject this into
- * OpenPeripheral's AdapterPeripheral to enable getting the target TileEntity. It is also
- * recommended you implement it on the peripheral if you use {@link IPeripheralHost}
+ * OpenPeripheral's AdapterPeripheral to enable getting the target TileEntity.
  */
-public interface IPeripheralTargeted extends IPeripheral {
+public interface IPeripheralTargeted {
 	/**
 	 * Get the object this peripheral targets. This is generally a TileEntity
 	 *

--- a/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralTargeted.java
+++ b/src/api/java/org/squiddev/cctweaks/api/peripheral/IPeripheralTargeted.java
@@ -1,0 +1,19 @@
+package org.squiddev.cctweaks.api.peripheral;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+
+/**
+ * Used to denote a peripheral that targets a TileEntity or other object in game
+ *
+ * This can be used from the Java side to access additional methods. We inject this into
+ * OpenPeripheral's AdapterPeripheral to enable getting the target TileEntity. It is also
+ * recommended you implement it on the peripheral if you use {@link IPeripheralHost}
+ */
+public interface IPeripheralTargeted extends IPeripheral {
+	/**
+	 * Get the object this peripheral targets. This is generally a TileEntity
+	 *
+	 * @return The target
+	 */
+	Object getTarget();
+}

--- a/src/main/java/org/squiddev/cctweaks/CCTweaks.java
+++ b/src/main/java/org/squiddev/cctweaks/CCTweaks.java
@@ -3,6 +3,7 @@ package org.squiddev.cctweaks;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import dan200.computercraft.ComputerCraft;
 import net.minecraft.creativetab.CreativeTabs;
@@ -34,5 +35,10 @@ public class CCTweaks {
 	@EventHandler
 	public void init(FMLInitializationEvent event) {
 		Registry.init();
+	}
+
+	@EventHandler
+	public void postInit(FMLPostInitializationEvent event) {
+		Registry.postInit();
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/CCTweaks.java
+++ b/src/main/java/org/squiddev/cctweaks/CCTweaks.java
@@ -16,7 +16,7 @@ public class CCTweaks {
 	public static final String NAME = ID;
 	public static final String VERSION = "${mod_version}";
 	public static final String RESOURCE_DOMAIN = ID.toLowerCase();
-	public static final String DEPENDENCIES = "required-after:ComputerCraft;after:CCTurtle;after:ForgeMultipart;";
+	public static final String DEPENDENCIES = "required-after:ComputerCraft;after:CCTurtle;after:ForgeMultipart;after:OpenPeripheralCore;";
 
 	public static final String ROOT_NAME = "org.squiddev.cctweaks.";
 	public static final String GUI_FACTORY = ROOT_NAME + "client.gui.GuiConfigFactory";

--- a/src/main/java/org/squiddev/cctweaks/blocks/BlockBase.java
+++ b/src/main/java/org/squiddev/cctweaks/blocks/BlockBase.java
@@ -92,4 +92,8 @@ public abstract class BlockBase<T extends TileBase> extends BlockContainer imple
 	@Override
 	public void init() {
 	}
+
+	@Override
+	public void postInit() {
+	}
 }

--- a/src/main/java/org/squiddev/cctweaks/core/API.java
+++ b/src/main/java/org/squiddev/cctweaks/core/API.java
@@ -3,9 +3,11 @@ package org.squiddev.cctweaks.core;
 import org.squiddev.cctweaks.api.ICCTweaksAPI;
 import org.squiddev.cctweaks.api.network.INetworkRegistry;
 import org.squiddev.cctweaks.api.network.INetworkVisitor;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHelpers;
 import org.squiddev.cctweaks.api.turtle.ITurtleFuelRegistry;
 import org.squiddev.cctweaks.core.network.NetworkRegistry;
 import org.squiddev.cctweaks.core.network.visitor.NetworkVisitor;
+import org.squiddev.cctweaks.core.peripheral.PeripheralHelpers;
 import org.squiddev.cctweaks.core.turtle.TurtleFuelRegistry;
 
 /**
@@ -15,6 +17,7 @@ public final class API implements ICCTweaksAPI {
 	private final INetworkVisitor networkVisitor = new NetworkVisitor();
 	private final INetworkRegistry networkRegistry = new NetworkRegistry();
 	private final ITurtleFuelRegistry fuelRegistry = new TurtleFuelRegistry();
+	private final IPeripheralHelpers peripheralHelpers = new PeripheralHelpers();
 
 	@Override
 	public INetworkVisitor networkVisitor() {
@@ -29,5 +32,10 @@ public final class API implements ICCTweaksAPI {
 	@Override
 	public ITurtleFuelRegistry fuelRegistry() {
 		return fuelRegistry;
+	}
+
+	@Override
+	public IPeripheralHelpers peripheralHelpers() {
+		return peripheralHelpers;
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/core/asm/ASMTransformer.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/ASMTransformer.java
@@ -49,6 +49,7 @@ public class ASMTransformer implements IClassTransformer {
 			"openperipheral.addons.peripheralproxy.WrappedPeripheral",
 			"org.squiddev.cctweaks.core.patch.op.PeripheralProxy_Patch"
 		),
+		new PatchOpenPeripheralAdapter(),
 	};
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/core/asm/ASMTransformer.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/ASMTransformer.java
@@ -45,6 +45,10 @@ public class ASMTransformer implements IClassTransformer {
 			"dan200.computercraft.core.apis.PeripheralAPI",
 			"org.squiddev.cctweaks.core.patch.PeripheralAPI_Patch"
 		),
+		new ClassPartialPatcher(
+			"openperipheral.addons.peripheralproxy.WrappedPeripheral",
+			"org.squiddev.cctweaks.core.patch.op.PeripheralProxy_Patch"
+		),
 	};
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/core/asm/ASMTransformer.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/ASMTransformer.java
@@ -9,7 +9,7 @@ import org.squiddev.cctweaks.core.asm.patch.IPatcher;
 import org.squiddev.cctweaks.integration.multipart.MultipartIntegration;
 
 public class ASMTransformer implements IClassTransformer {
-	protected IPatcher[] patches = {
+	protected final IPatcher[] patches = {
 		new ClassPatcher("org.luaj.vm2.lib.DebugLib"),
 		new ClassPatcher("org.luaj.vm2.lib.StringLib"),
 		new ClassReplacer(
@@ -50,6 +50,7 @@ public class ASMTransformer implements IClassTransformer {
 			"org.squiddev.cctweaks.core.patch.op.PeripheralProxy_Patch"
 		),
 		new PatchOpenPeripheralAdapter(),
+		new PatchOpenModule(),
 	};
 
 	@Override

--- a/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenModule.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenModule.java
@@ -4,7 +4,7 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
-import org.squiddev.cctweaks.api.peripheral.INetworkedAdapter;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralEnvironments;
 import org.squiddev.cctweaks.core.asm.chickenlib.ASMMatcher;
 import org.squiddev.cctweaks.core.asm.chickenlib.InsnListSection;
 import org.squiddev.cctweaks.core.asm.patch.IPatcher;
@@ -13,7 +13,7 @@ import org.squiddev.cctweaks.core.utils.DebugLogger;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 
 /**
- * Add {@link org.squiddev.cctweaks.api.peripheral.INetworkedAdapter#ARG_NETWORK} to ComputerCraft's
+ * Add {@link IPeripheralEnvironments#ARG_NETWORK} to ComputerCraft's
  * environment list:
  *
  * https://github.com/OpenMods/OpenPeripheral/blob/master/src/main/java/openperipheral/interfaces/cc/ModuleComputerCraft.java#L33-L37
@@ -56,7 +56,7 @@ public class PatchOpenModule implements IPatcher {
 
 					// Add the same as before but with INetworkAccess instead
 					InsnList insert = new InsnList();
-					insert.add(new LdcInsnNode(INetworkedAdapter.ARG_NETWORK));
+					insert.add(new LdcInsnNode(IPeripheralEnvironments.ARG_NETWORK));
 					insert.add(new LdcInsnNode(Type.getType("Lorg/squiddev/cctweaks/api/network/INetworkAccess;")));
 					insert.add(new MethodInsnNode(INVOKEVIRTUAL,
 						"openperipheral/adapter/composed/MethodSelector",

--- a/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenModule.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenModule.java
@@ -1,0 +1,87 @@
+package org.squiddev.cctweaks.core.asm;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+import org.squiddev.cctweaks.api.peripheral.INetworkedAdapter;
+import org.squiddev.cctweaks.core.asm.chickenlib.ASMMatcher;
+import org.squiddev.cctweaks.core.asm.chickenlib.InsnListSection;
+import org.squiddev.cctweaks.core.asm.patch.IPatcher;
+import org.squiddev.cctweaks.core.utils.DebugLogger;
+
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+
+/**
+ * Add {@link org.squiddev.cctweaks.api.peripheral.INetworkedAdapter#ARG_NETWORK} to ComputerCraft's
+ * environment list:
+ *
+ * https://github.com/OpenMods/OpenPeripheral/blob/master/src/main/java/openperipheral/interfaces/cc/ModuleComputerCraft.java#L33-L37
+ */
+public class PatchOpenModule implements IPatcher {
+	public final String className = "openperipheral.interfaces.cc.ModuleComputerCraft";
+
+	@Override
+	public boolean matches(String className) {
+		return className.equals(this.className);
+	}
+
+	@Override
+	public byte[] patch(String className, byte[] bytes) {
+		try {
+			ClassNode classNode = new ClassNode();
+			new ClassReader(bytes).accept(classNode, ClassReader.EXPAND_FRAMES);
+
+			boolean changed = false;
+			for (MethodNode method : classNode.methods) {
+				if (method.name.equals("<clinit>")) {
+					/*
+						LDC "computer"
+					    LDC Ldan200/computercraft/api/peripheral/IComputerAccess;.class
+					    INVOKEVIRTUAL openperipheral/adapter/composed/MethodSelector.addProvidedEnv
+					        (Ljava/lang/String;Ljava/lang/Class;)Lopenperipheral/adapter/composed/MethodSelector;
+					 */
+
+					InsnList addComputer = new InsnList();
+					addComputer.add(new LdcInsnNode("computer"));
+					addComputer.add(new LdcInsnNode(Type.getType("Ldan200/computercraft/api/peripheral/IComputerAccess;")));
+					addComputer.add(new MethodInsnNode(INVOKEVIRTUAL,
+						"openperipheral/adapter/composed/MethodSelector",
+						"addProvidedEnv",
+						"(Ljava/lang/String;Ljava/lang/Class;)Lopenperipheral/adapter/composed/MethodSelector;",
+						false
+					));
+
+					InsnListSection found = ASMMatcher.findOnce(method.instructions, new InsnListSection(addComputer), true);
+
+					// Add the same as before but with INetworkAccess instead
+					InsnList insert = new InsnList();
+					insert.add(new LdcInsnNode(INetworkedAdapter.ARG_NETWORK));
+					insert.add(new LdcInsnNode(Type.getType("Lorg/squiddev/cctweaks/api/network/INetworkAccess;")));
+					insert.add(new MethodInsnNode(INVOKEVIRTUAL,
+						"openperipheral/adapter/composed/MethodSelector",
+						"addProvidedEnv",
+						"(Ljava/lang/String;Ljava/lang/Class;)Lopenperipheral/adapter/composed/MethodSelector;",
+						false
+					));
+
+					found.insert(insert);
+
+					changed = true;
+					break;
+				}
+			}
+
+			if (!changed) throw new RuntimeException("Cannot find <clinit> method");
+
+			DebugLogger.debug(MARKER, "Injected custom " + className);
+
+			ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+			classNode.accept(writer);
+			return writer.toByteArray();
+		} catch (Exception e) {
+			DebugLogger.error(MARKER, "Cannot replace " + className + ", falling back to default", e);
+			return bytes;
+		}
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenPeripheralAdapter.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenPeripheralAdapter.java
@@ -25,7 +25,6 @@ import static org.objectweb.asm.Opcodes.*;
  */
 public class PatchOpenPeripheralAdapter extends ClassPartialPatcher {
 	public static final String METHOD_CALL = "Lopenperipheral/adapter/IMethodCall;";
-	public static final String NETWORK_ACCESS = "Lorg/squiddev/cctweaks/api/network/INetworkAccess;";
 
 	public PatchOpenPeripheralAdapter() {
 		super("openperipheral.interfaces.cc.wrappers.AdapterPeripheral", "org.squiddev.cctweaks.core.patch.op.AdapterPeripheral_Patch");

--- a/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenPeripheralAdapter.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenPeripheralAdapter.java
@@ -1,0 +1,106 @@
+package org.squiddev.cctweaks.core.asm;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.tree.*;
+import org.squiddev.cctweaks.api.peripheral.INetworkedAdapter;
+import org.squiddev.cctweaks.core.asm.chickenlib.ASMMatcher;
+import org.squiddev.cctweaks.core.asm.patch.ClassPartialPatcher;
+import org.squiddev.cctweaks.core.asm.patch.MergeVisitor;
+import org.squiddev.cctweaks.core.utils.DebugLogger;
+
+import java.util.Iterator;
+
+import static org.objectweb.asm.Opcodes.*;
+
+/**
+ * A custom patcher to allow us to also extend the environment
+ *
+ * Before changing anything check with
+ * <ul>
+ * <li>{@link org.squiddev.cctweaks.core.asm.PatchOpenPeripheralAdapter}</li>
+ * <li>{@link org.squiddev.cctweaks.core.patch.op.AdapterPeripheral_Patch}</li>
+ * </ul>
+ * to make sure it doesn't break anything
+ */
+public class PatchOpenPeripheralAdapter extends ClassPartialPatcher {
+	public static final String METHOD_CALL = "Lopenperipheral/adapter/IMethodCall;";
+	public static final String NETWORK_ACCESS = "Lorg/squiddev/cctweaks/api/network/INetworkAccess;";
+
+	public PatchOpenPeripheralAdapter() {
+		super("openperipheral.interfaces.cc.wrappers.AdapterPeripheral", "org.squiddev.cctweaks.core.patch.op.AdapterPeripheral_Patch");
+	}
+
+	@Override
+	public byte[] patch(String className, byte[] bytes) {
+		try {
+			ClassReader original = new ClassReader(bytes);
+			ClassNode originalNode = new ClassNode();
+			original.accept(originalNode, ClassReader.EXPAND_FRAMES);
+
+			for (MethodNode method : originalNode.methods) {
+				if (method.name.equals("call")) {
+
+					// Find the Object[] IMethodCall#call(Object[]) method
+					MethodInsnNode find = new MethodInsnNode(
+						INVOKEINTERFACE,
+						"openperipheral/adapter/IMethodCall",
+						"call",
+						"([Ljava/lang/Object;)[Ljava/lang/Object;",
+						true
+					);
+
+					Iterator<AbstractInsnNode> instructions = method.instructions.iterator();
+					boolean success = false;
+					while (instructions.hasNext()) {
+						AbstractInsnNode instruction = instructions.next();
+						if (ASMMatcher.insnEqual(find, instruction)) {
+							success = true;
+
+							// Before that, add an additional environment
+							InsnList insert = new InsnList();
+							insert.add(new LdcInsnNode(INetworkedAdapter.ARG_NETWORK));
+							insert.add(new VarInsnNode(ALOAD, 0));
+							insert.add(new FieldInsnNode(GETFIELD, patchType, "network", "Lorg/squiddev/cctweaks/core/network/NetworkAccessDelegate;"));
+							insert.add(new MethodInsnNode(
+								INVOKEINTERFACE,
+								"openperipheral/adapter/IMethodCall",
+								"setEnv",
+								"(Ljava/lang/String;Ljava/lang/Object;)" + METHOD_CALL,
+								true
+							));
+
+							// We want to get the previous one as this one will be ALOAD arguments
+							method.instructions.insertBefore(instruction.getPrevious(), insert);
+						}
+					}
+
+					if (success) {
+						DebugLogger.debug("Added additional environments into " + className);
+					} else {
+						DebugLogger.error("Cannot inject additional environments into " + className);
+					}
+
+					break;
+				}
+			}
+
+			ClassReader override = getSource(patchType + className.substring(classNameStart));
+			if (override == null) return bytes;
+			ClassWriter writer = new ClassWriter(0);
+
+			originalNode.accept(new MergeVisitor(writer, override, context));
+
+			DebugLogger.debug(MARKER, "Injected custom " + className);
+			return writer.toByteArray();
+		} catch (Exception e) {
+			DebugLogger.error(MARKER, "Cannot replace " + className + ", falling back to default", e);
+			return bytes;
+		}
+	}
+
+	@Override
+	public boolean matches(String className) {
+		return className.equals(this.className);
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenPeripheralAdapter.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/PatchOpenPeripheralAdapter.java
@@ -3,7 +3,7 @@ package org.squiddev.cctweaks.core.asm;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.*;
-import org.squiddev.cctweaks.api.peripheral.INetworkedAdapter;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralEnvironments;
 import org.squiddev.cctweaks.core.asm.chickenlib.ASMMatcher;
 import org.squiddev.cctweaks.core.asm.patch.ClassPartialPatcher;
 import org.squiddev.cctweaks.core.asm.patch.MergeVisitor;
@@ -58,7 +58,7 @@ public class PatchOpenPeripheralAdapter extends ClassPartialPatcher {
 
 							// Before that, add an additional environment
 							InsnList insert = new InsnList();
-							insert.add(new LdcInsnNode(INetworkedAdapter.ARG_NETWORK));
+							insert.add(new LdcInsnNode(IPeripheralEnvironments.ARG_NETWORK));
 							insert.add(new VarInsnNode(ALOAD, 0));
 							insert.add(new FieldInsnNode(GETFIELD, patchType, "network", "Lorg/squiddev/cctweaks/core/network/NetworkAccessDelegate;"));
 							insert.add(new MethodInsnNode(

--- a/src/main/java/org/squiddev/cctweaks/core/asm/PatchTurtle.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/PatchTurtle.java
@@ -2,12 +2,14 @@ package org.squiddev.cctweaks.core.asm;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.squiddev.cctweaks.core.Config;
 
-public class PatchTurtle implements Opcodes {
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+
+public class PatchTurtle {
 	/**
 	 * Disable a particular turtle command
 	 */

--- a/src/main/java/org/squiddev/cctweaks/core/asm/patch/ClassRewriter.java
+++ b/src/main/java/org/squiddev/cctweaks/core/asm/patch/ClassRewriter.java
@@ -1,9 +1,12 @@
 package org.squiddev.cctweaks.core.asm.patch;
 
 import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.TraceClassVisitor;
 import org.squiddev.cctweaks.core.utils.DebugLogger;
 
 import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 /**
  * Abstract class for rewriting classes
@@ -73,5 +76,24 @@ public abstract class ClassRewriter implements IPatcher {
 	 */
 	public boolean matches(String className) {
 		return className.startsWith(this.className);
+	}
+
+	/**
+	 * Dump the bytecode for this class.
+	 *
+	 * Example: {@code return dumpClass(writer.toByteArray());}
+	 *
+	 * @param bytes The bytes of this class
+	 * @return The bytes of this class (enable easier returning)
+	 */
+	public static byte[] dumpClass(byte[] bytes) {
+		ClassReader reader = new ClassReader(bytes);
+		StringWriter writer = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(writer);
+
+		reader.accept(new TraceClassVisitor(printWriter), 0);
+		DebugLogger.debug(writer.toString());
+
+		return bytes;
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/core/network/NetworkAccessDelegate.java
+++ b/src/main/java/org/squiddev/cctweaks/core/network/NetworkAccessDelegate.java
@@ -1,0 +1,53 @@
+package org.squiddev.cctweaks.core.network;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import org.squiddev.cctweaks.api.network.INetworkAccess;
+import org.squiddev.cctweaks.api.network.Packet;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A {@link INetworkAccess} implementation that delegates to other networks
+ */
+public class NetworkAccessDelegate implements INetworkAccess {
+	protected final Set<INetworkAccess> networks = new HashSet<INetworkAccess>();
+
+	@Override
+	public Map<String, IPeripheral> peripheralsByName() {
+		// We can't cache this at all as we can't receive network changed events
+		Map<String, IPeripheral> peripherals = new HashMap<String, IPeripheral>();
+		for (INetworkAccess network : networks) {
+			peripherals.putAll(network.peripheralsByName());
+		}
+		return peripherals;
+	}
+
+	@Override
+	public void invalidateNetwork() {
+		for (INetworkAccess network : networks) {
+			network.invalidateNetwork();
+		}
+	}
+
+	@Override
+	public boolean transmitPacket(Packet packet) {
+		// To consider, should we always fail if one fails, or succeed if one succeeds?
+
+		boolean success = false;
+		for (INetworkAccess network : networks) {
+			success |= network.transmitPacket(packet);
+		}
+		return success;
+	}
+
+	public void add(INetworkAccess network) {
+		networks.add(network);
+	}
+
+	public void remove(INetworkAccess network) {
+		networks.remove(network);
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/network/modem/BasicModemPeripheral.java
+++ b/src/main/java/org/squiddev/cctweaks/core/network/modem/BasicModemPeripheral.java
@@ -107,10 +107,8 @@ public class BasicModemPeripheral<T extends BasicModem> extends ModemPeripheral 
 
 				// Get the peripheral and call it
 				PeripheralAccess access = modem.peripheralWrappersByName.get(remoteName);
-				if (access != null) {
-					return access.callMethod(context, methodName, methodArgs);
-				}
-				return null;
+				if (access == null) throw new LuaException("No peripheral: " + remoteName);
+				return access.callMethod(context, methodName, methodArgs);
 			}
 		}
 

--- a/src/main/java/org/squiddev/cctweaks/core/patch/op/AdapterPeripheral_Patch.java
+++ b/src/main/java/org/squiddev/cctweaks/core/patch/op/AdapterPeripheral_Patch.java
@@ -1,0 +1,56 @@
+package org.squiddev.cctweaks.core.patch.op;
+
+import org.squiddev.cctweaks.api.network.INetworkAccess;
+import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
+import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralTargeted;
+import org.squiddev.cctweaks.core.asm.patch.MergeVisitor;
+import org.squiddev.cctweaks.core.network.NetworkAccessDelegate;
+
+/**
+ * Before changing anything check with
+ * <ul>
+ * <li>{@link org.squiddev.cctweaks.core.asm.PatchOpenPeripheralAdapter}</li>
+ * <li>{@link org.squiddev.cctweaks.core.patch.op.AdapterPeripheral_Patch}</li>
+ * </ul>
+ * to make sure it doesn't break anything
+ */
+public class AdapterPeripheral_Patch implements IPeripheralTargeted, INetworkedPeripheral {
+	@MergeVisitor.Stub
+	protected final Object target;
+
+	protected NetworkAccessDelegate network;
+
+	@MergeVisitor.Stub
+	public AdapterPeripheral_Patch(Object target) {
+		this.target = target;
+	}
+
+	@Override
+	public Object getTarget() {
+		return target;
+	}
+
+	public NetworkAccessDelegate getNetworkAccess() {
+		if (network == null) return network = new NetworkAccessDelegate();
+		return network;
+	}
+
+	@Override
+	public void attachToNetwork(INetworkAccess network, String name) {
+		getNetworkAccess().add(network);
+	}
+
+	@Override
+	public void detachFromNetwork(INetworkAccess network, String name) {
+		getNetworkAccess().remove(network);
+	}
+
+	@Override
+	public void networkInvalidated(INetworkAccess network) {
+	}
+
+	@Override
+	public void receivePacket(Packet packet, int distanceTravelled) {
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/patch/op/PeripheralProxy_Patch.java
+++ b/src/main/java/org/squiddev/cctweaks/core/patch/op/PeripheralProxy_Patch.java
@@ -1,8 +1,5 @@
 package org.squiddev.cctweaks.core.patch.op;
 
-import dan200.computercraft.api.lua.ILuaContext;
-import dan200.computercraft.api.lua.LuaException;
-import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import org.squiddev.cctweaks.api.network.INetworkAccess;
 import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
@@ -53,39 +50,5 @@ public class PeripheralProxy_Patch implements INetworkedPeripheral, IPeripheralP
 	@Override
 	public IPeripheral getBasePeripheral() {
 		return peripheral;
-	}
-
-	@Override
-	@MergeVisitor.Stub
-	public String getType() {
-		return null;
-	}
-
-	@Override
-	@MergeVisitor.Stub
-	public String[] getMethodNames() {
-		return null;
-	}
-
-	@Override
-	@MergeVisitor.Stub
-	public Object[] callMethod(IComputerAccess computer, ILuaContext context, int index, Object[] params) throws LuaException, InterruptedException {
-		return null;
-	}
-
-	@Override
-	@MergeVisitor.Stub
-	public void attach(IComputerAccess paramIComputerAccess) {
-	}
-
-	@Override
-	@MergeVisitor.Stub
-	public void detach(IComputerAccess paramIComputerAccess) {
-	}
-
-	@Override
-	@MergeVisitor.Stub
-	public boolean equals(IPeripheral paramIPeripheral) {
-		return false;
 	}
 }

--- a/src/main/java/org/squiddev/cctweaks/core/patch/op/PeripheralProxy_Patch.java
+++ b/src/main/java/org/squiddev/cctweaks/core/patch/op/PeripheralProxy_Patch.java
@@ -1,0 +1,91 @@
+package org.squiddev.cctweaks.core.patch.op;
+
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import org.squiddev.cctweaks.api.network.INetworkAccess;
+import org.squiddev.cctweaks.api.network.INetworkedPeripheral;
+import org.squiddev.cctweaks.api.network.Packet;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralProxy;
+import org.squiddev.cctweaks.core.asm.patch.MergeVisitor;
+
+/**
+ * PeripheralProxy rewrite with INetworkedPeripheral support
+ */
+public class PeripheralProxy_Patch implements INetworkedPeripheral, IPeripheralProxy {
+	@MergeVisitor.Stub
+	private final IPeripheral peripheral;
+
+	@MergeVisitor.Stub
+	public PeripheralProxy_Patch(IPeripheral peripheral) {
+		this.peripheral = peripheral;
+	}
+
+	@Override
+	public void attachToNetwork(INetworkAccess network, String name) {
+		if (peripheral instanceof INetworkedPeripheral) {
+			((INetworkedPeripheral) peripheral).attachToNetwork(network, name);
+		}
+	}
+
+	@Override
+	public void detachFromNetwork(INetworkAccess network, String name) {
+		if (peripheral instanceof INetworkedPeripheral) {
+			((INetworkedPeripheral) peripheral).detachFromNetwork(network, name);
+		}
+	}
+
+	@Override
+	public void networkInvalidated(INetworkAccess network) {
+		if (peripheral instanceof INetworkedPeripheral) {
+			((INetworkedPeripheral) peripheral).networkInvalidated(network);
+		}
+	}
+
+	@Override
+	public void receivePacket(Packet packet, int distanceTravelled) {
+		if (peripheral instanceof INetworkedPeripheral) {
+			((INetworkedPeripheral) peripheral).receivePacket(packet, distanceTravelled);
+		}
+	}
+
+	@Override
+	public IPeripheral getBasePeripheral() {
+		return peripheral;
+	}
+
+	@Override
+	@MergeVisitor.Stub
+	public String getType() {
+		return null;
+	}
+
+	@Override
+	@MergeVisitor.Stub
+	public String[] getMethodNames() {
+		return null;
+	}
+
+	@Override
+	@MergeVisitor.Stub
+	public Object[] callMethod(IComputerAccess computer, ILuaContext context, int index, Object[] params) throws LuaException, InterruptedException {
+		return null;
+	}
+
+	@Override
+	@MergeVisitor.Stub
+	public void attach(IComputerAccess paramIComputerAccess) {
+	}
+
+	@Override
+	@MergeVisitor.Stub
+	public void detach(IComputerAccess paramIComputerAccess) {
+	}
+
+	@Override
+	@MergeVisitor.Stub
+	public boolean equals(IPeripheral paramIPeripheral) {
+		return false;
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpers.java
+++ b/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpers.java
@@ -1,0 +1,21 @@
+package org.squiddev.cctweaks.core.peripheral;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHelpers;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralProxy;
+
+public class PeripheralHelpers implements IPeripheralHelpers {
+	@Override
+	public IPeripheral getBasePeripheral(IPeripheral peripheral) {
+		IPeripheral previous = null;
+
+		while (peripheral != null) {
+			previous = peripheral;
+			peripheral = peripheral instanceof IPeripheralProxy ?
+				((IPeripheralProxy) peripheral).getBasePeripheral() :
+				null;
+		}
+
+		return previous;
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpers.java
+++ b/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpers.java
@@ -3,6 +3,7 @@ package org.squiddev.cctweaks.core.peripheral;
 import dan200.computercraft.api.peripheral.IPeripheral;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralHelpers;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralProxy;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralTargeted;
 
 public class PeripheralHelpers implements IPeripheralHelpers {
 	@Override
@@ -11,6 +12,26 @@ public class PeripheralHelpers implements IPeripheralHelpers {
 
 		while (peripheral != null) {
 			previous = peripheral;
+			peripheral = peripheral instanceof IPeripheralProxy ?
+				((IPeripheralProxy) peripheral).getBasePeripheral() :
+				null;
+		}
+
+		return previous;
+	}
+
+	@Override
+	public Object getTarget(IPeripheral peripheral) {
+		IPeripheral previous = null;
+
+		while (peripheral != null) {
+			previous = peripheral;
+
+			if (peripheral instanceof IPeripheralTargeted) {
+				Object result = ((IPeripheralTargeted) peripheral).getTarget();
+				if (result != null) return result;
+			}
+
 			peripheral = peripheral instanceof IPeripheralProxy ?
 				((IPeripheralProxy) peripheral).getBasePeripheral() :
 				null;

--- a/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHostProvider.java
+++ b/src/main/java/org/squiddev/cctweaks/core/peripheral/PeripheralHostProvider.java
@@ -6,21 +6,12 @@ import dan200.computercraft.api.peripheral.IPeripheralProvider;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralHost;
-import org.squiddev.cctweaks.core.registry.IModule;
+import org.squiddev.cctweaks.core.registry.Module;
 
 /**
  * Adds support for {@link org.squiddev.cctweaks.api.peripheral.IPeripheralHost}
  */
-public class PeripheralHostProvider implements IModule, IPeripheralProvider {
-	@Override
-	public boolean canLoad() {
-		return true;
-	}
-
-	@Override
-	public void preInit() {
-	}
-
+public class PeripheralHostProvider extends Module implements IPeripheralProvider {
 	@Override
 	public void init() {
 		ComputerCraftAPI.registerPeripheralProvider(this);

--- a/src/main/java/org/squiddev/cctweaks/core/registry/IModule.java
+++ b/src/main/java/org/squiddev/cctweaks/core/registry/IModule.java
@@ -20,4 +20,9 @@ public interface IModule {
 	 * @see cpw.mods.fml.common.Mod.EventHandler
 	 */
 	void init();
+
+	/**
+	 * @see cpw.mods.fml.common.Mod.EventHandler
+	 */
+	void postInit();
 }

--- a/src/main/java/org/squiddev/cctweaks/core/registry/Module.java
+++ b/src/main/java/org/squiddev/cctweaks/core/registry/Module.java
@@ -1,0 +1,19 @@
+package org.squiddev.cctweaks.core.registry;
+
+/**
+ * Default implementation of {@link IModule}
+ */
+public abstract class Module implements IModule {
+	public boolean canLoad() {
+		return true;
+	}
+
+	public void preInit() {
+	}
+
+	public void init() {
+	}
+
+	public void postInit() {
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/core/registry/Registry.java
+++ b/src/main/java/org/squiddev/cctweaks/core/registry/Registry.java
@@ -31,6 +31,7 @@ public final class Registry {
 
 	private static boolean preInit = false;
 	private static boolean init = false;
+	private static boolean postInit = false;
 
 	static {
 		addModule(itemComputerUpgrade = new ItemComputerUpgrade());
@@ -60,7 +61,10 @@ public final class Registry {
 
 		if (preInit && module.canLoad()) {
 			module.preInit();
-			if (init) module.init();
+			if (init) {
+				module.init();
+				if (postInit) module.postInit();
+			}
 		}
 	}
 
@@ -80,6 +84,17 @@ public final class Registry {
 		init = true;
 		for (IModule module : modules) {
 			if (module.canLoad()) module.init();
+		}
+	}
+
+	public static void postInit() {
+		if (!preInit) throw new IllegalStateException("Cannot init before preInit");
+		if (!init) throw new IllegalStateException("Cannot postInit before init");
+		if (postInit) throw new IllegalStateException("Attempting to postInit twice");
+
+		postInit = true;
+		for (IModule module : modules) {
+			if (module.canLoad()) module.postInit();
 		}
 	}
 
@@ -106,6 +121,11 @@ public final class Registry {
 		@Override
 		public void init() {
 			base.init();
+		}
+
+		@Override
+		public void postInit() {
+			base.postInit();
 		}
 	}
 

--- a/src/main/java/org/squiddev/cctweaks/core/registry/Registry.java
+++ b/src/main/java/org/squiddev/cctweaks/core/registry/Registry.java
@@ -9,6 +9,7 @@ import org.squiddev.cctweaks.core.turtle.DefaultTurtleProviders;
 import org.squiddev.cctweaks.integration.IndustrialCraftIntegration;
 import org.squiddev.cctweaks.integration.RedstoneFluxIntegration;
 import org.squiddev.cctweaks.integration.multipart.MultipartIntegration;
+import org.squiddev.cctweaks.integration.openperipheral.OpenPeripheralIntegration;
 import org.squiddev.cctweaks.items.ItemComputerUpgrade;
 import org.squiddev.cctweaks.items.ItemDataCard;
 import org.squiddev.cctweaks.items.ItemDebugger;
@@ -43,6 +44,7 @@ public final class Registry {
 		addModule(new BlockDebug());
 
 		addModule(new MultipartIntegration());
+		addModule(new OpenPeripheralIntegration());
 
 		addModule(new PeripheralHostProvider());
 

--- a/src/main/java/org/squiddev/cctweaks/core/turtle/DefaultTurtleProviders.java
+++ b/src/main/java/org/squiddev/cctweaks/core/turtle/DefaultTurtleProviders.java
@@ -15,21 +15,12 @@ import org.squiddev.cctweaks.api.network.INetworkNodeHost;
 import org.squiddev.cctweaks.api.network.INetworkNodeProvider;
 import org.squiddev.cctweaks.api.network.NetworkAPI;
 import org.squiddev.cctweaks.api.turtle.ITurtleFuelProvider;
-import org.squiddev.cctweaks.core.registry.IModule;
+import org.squiddev.cctweaks.core.registry.Module;
 
 /**
  * Registers turtle related things
  */
-public class DefaultTurtleProviders implements IModule {
-	@Override
-	public boolean canLoad() {
-		return true;
-	}
-
-	@Override
-	public void preInit() {
-	}
-
+public class DefaultTurtleProviders extends Module {
 	public void init() {
 		// Add default furnace fuel provider
 		CCTweaksAPI.instance().fuelRegistry().addFuelProvider(new ITurtleFuelProvider() {

--- a/src/main/java/org/squiddev/cctweaks/core/utils/InventoryUtils.java
+++ b/src/main/java/org/squiddev/cctweaks/core/utils/InventoryUtils.java
@@ -1,0 +1,212 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 Open Mods
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.squiddev.cctweaks.core.utils;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import net.minecraft.block.Block;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.inventory.InventoryLargeChest;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.Set;
+
+
+/**
+ * Various inventory code taken from OpenModsLib because I am lazy
+ */
+public class InventoryUtils {
+
+	public static boolean areItemAndTagEqual(final ItemStack stackA, ItemStack stackB) {
+		return stackA.isItemEqual(stackB) && ItemStack.areItemStackTagsEqual(stackA, stackB);
+	}
+
+	public static boolean areMergeCandidates(ItemStack source, ItemStack target) {
+		return areItemAndTagEqual(source, target) && target.stackSize < target.getMaxStackSize();
+	}
+
+	public static ItemStack copyAndChange(ItemStack stack, int newSize) {
+		ItemStack copy = stack.copy();
+		copy.stackSize = newSize;
+		return copy;
+	}
+
+	public static void removeFromSlot(IInventory inventory, int slot, int amount) {
+		ItemStack sourceStack = inventory.getStackInSlot(slot);
+		sourceStack.stackSize -= amount;
+		if (sourceStack.stackSize == 0) {
+			inventory.setInventorySlotContents(slot, null);
+		} else {
+			// Paranoia? Always!
+			inventory.setInventorySlotContents(slot, sourceStack);
+		}
+	}
+
+	private static IInventory doubleChestFix(TileEntity te) {
+		final World world = te.getWorldObj();
+		final int x = te.xCoord;
+		final int y = te.yCoord;
+		final int z = te.zCoord;
+		final Block block = te.getBlockType();
+		if (world.getBlock(x - 1, y, z) == block) {
+			return new InventoryLargeChest("Large chest", (IInventory) world.getTileEntity(x - 1, y, z), (IInventory) te);
+		}
+		if (world.getBlock(x + 1, y, z) == block) {
+			return new InventoryLargeChest("Large chest", (IInventory) te, (IInventory) world.getTileEntity(x + 1, y, z));
+		}
+		if (world.getBlock(x, y, z - 1) == block) {
+			return new InventoryLargeChest("Large chest", (IInventory) world.getTileEntity(x, y, z - 1), (IInventory) te);
+		}
+		if (world.getBlock(x, y, z + 1) == block) {
+			return new InventoryLargeChest("Large chest", (IInventory) te, (IInventory) world.getTileEntity(x, y, z + 1));
+		}
+		return (te instanceof IInventory) ? (IInventory) te : null;
+	}
+
+	public static IInventory getInventory(IInventory inventory) {
+		if (inventory instanceof TileEntityChest) return doubleChestFix((TileEntity) inventory);
+		return inventory;
+	}
+
+	public static boolean insertItemIntoInventory(IInventory inventory, ItemStack stack, ForgeDirection side, int intoSlot) {
+		if (stack == null) return false;
+
+		final int sideId = side.ordinal();
+
+		final Set<Integer> attemptSlots = Sets.newTreeSet();
+
+		// if it's a sided inventory, get all the accessible slots
+		final boolean isSidedInventory = inventory instanceof ISidedInventory && side != ForgeDirection.UNKNOWN;
+
+		if (isSidedInventory) {
+			int[] accessibleSlots = ((ISidedInventory) inventory).getAccessibleSlotsFromSide(sideId);
+			for (int slot : accessibleSlots) {
+				attemptSlots.add(slot);
+			}
+		} else {
+			// if it's just a standard inventory, get all slots
+			for (int a = 0; a < inventory.getSizeInventory(); a++) {
+				attemptSlots.add(a);
+			}
+		}
+
+		if (intoSlot > -1) attemptSlots.retainAll(ImmutableSet.of(intoSlot));
+
+		if (attemptSlots.isEmpty()) return false;
+
+		boolean result = false;
+		for (Integer slot : attemptSlots) {
+			if (stack.stackSize <= 0) break;
+			if (isSidedInventory && !((ISidedInventory) inventory).canInsertItem(slot, stack, sideId)) continue;
+			result |= tryInsertStack(inventory, slot, stack);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Move an item from the fromInventory, into the target. The target can be
+	 * an inventory or pipe.
+	 * Double checks are automagically wrapped. If you're not bothered what slot
+	 * you insert into, pass -1 for intoSlot. If you're passing false for
+	 * doMove, it'll create a dummy inventory and its calculations on that
+	 * instead
+	 *
+	 * @param fromInventory the inventory the item is coming from
+	 * @param fromSlot      the slot the item is coming from
+	 * @param toInventory   the inventory you want the item to be put into. can be BC pipe
+	 *                      or IInventory
+	 * @param intoSlot      the target slot. Pass -1 for any slot
+	 * @param maxAmount     The maximum amount you wish to pass
+	 * @param direction     The direction of the move. Pass UNKNOWN if not applicable
+	 * @return The amount of items moved
+	 */
+	public static int moveItemInto(IInventory fromInventory, int fromSlot, IInventory toInventory, int intoSlot, int maxAmount, ForgeDirection direction) {
+		fromInventory = InventoryUtils.getInventory(fromInventory);
+
+		ItemStack sourceStack = fromInventory.getStackInSlot(fromSlot);
+		if (sourceStack == null || maxAmount <= 0) return 0;
+
+		if (fromInventory instanceof ISidedInventory
+			&& !((ISidedInventory) fromInventory).canExtractItem(fromSlot, sourceStack, direction.ordinal())) {
+			return 0;
+		}
+
+		final int amountToMove = Math.min(sourceStack.stackSize, maxAmount);
+		ItemStack insertedStack = InventoryUtils.copyAndChange(sourceStack, amountToMove);
+
+		IInventory targetInventory = InventoryUtils.getInventory(toInventory);
+		ForgeDirection side = direction.getOpposite();
+		// try insert the item into the target inventory. this'll reduce the
+		// stackSize of our stack
+		insertItemIntoInventory(targetInventory, insertedStack, side, intoSlot);
+		int inserted = amountToMove - insertedStack.stackSize;
+
+		InventoryUtils.removeFromSlot(fromInventory, fromSlot, inserted);
+
+		return inserted;
+	}
+
+	/**
+	 * Try to merge the supplied stack into the supplied slot in the target inventory
+	 *
+	 * @param targetInventory Although it doesn't return anything, it'll REDUCE the stack
+	 *                        size of the stack that you pass in
+	 * @param slot            The slot to insert into
+	 * @param stack           The stack to insert
+	 */
+	public static boolean tryInsertStack(IInventory targetInventory, int slot, ItemStack stack) {
+		if (targetInventory.isItemValidForSlot(slot, stack)) {
+			ItemStack targetStack = targetInventory.getStackInSlot(slot);
+			if (targetStack == null) {
+				int limit = targetInventory.getInventoryStackLimit();
+				if (limit < stack.stackSize) {
+					targetInventory.setInventorySlotContents(slot, stack.splitStack(limit));
+				} else {
+					targetInventory.setInventorySlotContents(slot, stack.copy());
+					stack.stackSize = 0;
+				}
+				return true;
+			} else {
+				if (targetInventory.isItemValidForSlot(slot, stack) &&
+					InventoryUtils.areMergeCandidates(stack, targetStack)) {
+					int space = targetStack.getMaxStackSize() - targetStack.stackSize;
+					int mergeAmount = Math.min(space, stack.stackSize);
+					ItemStack copy = targetStack.copy();
+					copy.stackSize += mergeAmount;
+					targetInventory.setInventorySlotContents(slot, copy);
+					stack.stackSize -= mergeAmount;
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+}

--- a/src/main/java/org/squiddev/cctweaks/integration/APIIntegration.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/APIIntegration.java
@@ -1,12 +1,12 @@
 package org.squiddev.cctweaks.integration;
 
 import cpw.mods.fml.common.ModAPIManager;
-import org.squiddev.cctweaks.core.registry.IModule;
+import org.squiddev.cctweaks.core.registry.Module;
 
 /**
  * A module that is loaded when an API is on the class path
  */
-public abstract class APIIntegration implements IModule {
+public abstract class APIIntegration extends Module {
 	public final String apiName;
 
 	public APIIntegration(String modName) {

--- a/src/main/java/org/squiddev/cctweaks/integration/IndustrialCraftIntegration.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/IndustrialCraftIntegration.java
@@ -17,10 +17,6 @@ public class IndustrialCraftIntegration extends APIIntegration {
 	}
 
 	@Override
-	public void preInit() {
-	}
-
-	@Override
 	public void init() {
 		CCTweaksAPI.instance().fuelRegistry().addFuelProvider(new ITurtleFuelProvider() {
 			@Override

--- a/src/main/java/org/squiddev/cctweaks/integration/ModIntegration.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/ModIntegration.java
@@ -1,12 +1,12 @@
 package org.squiddev.cctweaks.integration;
 
 import cpw.mods.fml.common.Loader;
-import org.squiddev.cctweaks.core.registry.IModule;
+import org.squiddev.cctweaks.core.registry.Module;
 
 /**
  * A module that is loaded when a mod is installed
  */
-public abstract class ModIntegration implements IModule {
+public abstract class ModIntegration extends Module {
 	public final String modName;
 
 	public ModIntegration(String modName) {

--- a/src/main/java/org/squiddev/cctweaks/integration/RedstoneFluxIntegration.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/RedstoneFluxIntegration.java
@@ -14,11 +14,7 @@ public class RedstoneFluxIntegration extends APIIntegration {
 	public RedstoneFluxIntegration() {
 		super("CoFHAPI|energy");
 	}
-
-	@Override
-	public void preInit() {
-	}
-
+	
 	@Override
 	public void init() {
 		CCTweaksAPI.instance().fuelRegistry().addFuelProvider(new ITurtleFuelProvider() {

--- a/src/main/java/org/squiddev/cctweaks/integration/openperipheral/AdapterNetworkedInventory.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/openperipheral/AdapterNetworkedInventory.java
@@ -38,8 +38,6 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 		return null;
 	}
 
-	public static final INetworkAccess network = null;
-
 	@Alias("pullItemIntoSlotRemote")
 	@ScriptCallable(returnTypes = ReturnType.NUMBER, description = "Pull an item from a slot in another inventory into a slot in this one. Returns the amount of items moved")
 	public int pullItemRemote(
@@ -47,7 +45,9 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 		@Arg(name = "remoteName", description = "The name of the remote inventory") String remote,
 		@Arg(name = "slot", description = "The slot in the OTHER inventory that you're pulling from") int fromSlot,
 		@Optionals @Arg(name = "maxAmount", description = "The maximum amount of items you want to pull") Integer maxAmount,
-		@Arg(name = "intoSlot", description = "The slot in the current inventory that you want to pull into") Integer intoSlot
+		@Arg(name = "direction", description = "The direction to pull from the OTHER inventory") ForgeDirection fromDirection,
+		@Arg(name = "intoSlot", description = "The slot in the current inventory that you want to pull into") Integer intoSlot,
+		@Arg(name = "direction", description = "The direction to push into the current inventory") ForgeDirection intoDirection
 	) {
 		Preconditions.checkNotNull(network, "Cannot find the network");
 
@@ -55,8 +55,11 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 		final IInventory thisInventory = Preconditions.checkNotNull(InventoryUtils.getInventory(target), "Inventory not found");
 
 		if (otherInventory == target) return 0;
+
 		if (maxAmount == null) maxAmount = 64;
 		if (intoSlot == null) intoSlot = 0;
+		if (fromDirection == null) fromDirection = ForgeDirection.UNKNOWN;
+		if (intoDirection == null) intoDirection = ForgeDirection.UNKNOWN;
 
 		fromSlot -= 1;
 		intoSlot -= 1;
@@ -64,7 +67,7 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 		checkSlotId(otherInventory, fromSlot, "input");
 		checkSlotId(thisInventory, intoSlot, "output");
 
-		final int amount = InventoryUtils.moveItemInto(otherInventory, fromSlot, thisInventory, intoSlot, maxAmount, ForgeDirection.UNKNOWN);
+		final int amount = InventoryUtils.moveItemInto(otherInventory, fromSlot, fromDirection, thisInventory, intoSlot, intoDirection, maxAmount);
 		if (amount > 0) {
 			thisInventory.markDirty();
 			otherInventory.markDirty();
@@ -80,17 +83,21 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 		@Arg(name = "remoteName", description = "The name of the remote inventory") String remote,
 		@Arg(name = "slot", description = "The slot in the current inventory that you're pushing from") int fromSlot,
 		@Optionals @Arg(name = "maxAmount", description = "The maximum amount of items you want to push") Integer maxAmount,
-		@Arg(name = "intoSlot", description = "The slot in the other inventory that you want to push into") Integer intoSlot
+		@Arg(name = "direction", description = "The direction to push into the current inventory") ForgeDirection fromDirection,
+		@Arg(name = "intoSlot", description = "The slot in the other inventory that you want to push into") Integer intoSlot,
+		@Arg(name = "slot", description = "The slot in the other inventory that you're pulling from") ForgeDirection intoDirection
 	) {
 		Preconditions.checkNotNull(network, "Cannot find the network");
 
-		final IInventory otherInventory = getInventory(network, remote);
-		Preconditions.checkNotNull(otherInventory, "Other inventory not found");
-		final IInventory thisInventory = InventoryUtils.getInventory(target);
+		final IInventory otherInventory = Preconditions.checkNotNull(getInventory(network, remote), "Other inventory not found");
+		final IInventory thisInventory = Preconditions.checkNotNull(InventoryUtils.getInventory(target), "Inventory not found");
 
 		if (otherInventory == target) return 0;
+
 		if (maxAmount == null) maxAmount = 64;
 		if (intoSlot == null) intoSlot = 0;
+		if (fromDirection == null) fromDirection = ForgeDirection.UNKNOWN;
+		if (intoDirection == null) intoDirection = ForgeDirection.UNKNOWN;
 
 		fromSlot -= 1;
 		intoSlot -= 1;
@@ -98,7 +105,7 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 		checkSlotId(thisInventory, fromSlot, "input");
 		checkSlotId(otherInventory, intoSlot, "output");
 
-		int amount = InventoryUtils.moveItemInto(thisInventory, fromSlot, otherInventory, intoSlot, maxAmount, ForgeDirection.UNKNOWN);
+		int amount = InventoryUtils.moveItemInto(thisInventory, fromSlot, fromDirection, otherInventory, intoSlot, intoDirection, maxAmount);
 		if (amount > 0) {
 			thisInventory.markDirty();
 			otherInventory.markDirty();

--- a/src/main/java/org/squiddev/cctweaks/integration/openperipheral/AdapterNetworkedInventory.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/openperipheral/AdapterNetworkedInventory.java
@@ -1,0 +1,109 @@
+package org.squiddev.cctweaks.integration.openperipheral;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.inventory.IInventory;
+import net.minecraftforge.common.util.ForgeDirection;
+import openperipheral.api.adapter.Asynchronous;
+import openperipheral.api.adapter.IPeripheralAdapter;
+import openperipheral.api.adapter.method.*;
+import org.squiddev.cctweaks.api.CCTweaksAPI;
+import org.squiddev.cctweaks.api.network.INetworkAccess;
+import org.squiddev.cctweaks.api.peripheral.INetworkedAdapter;
+import org.squiddev.cctweaks.core.utils.InventoryUtils;
+
+/**
+ * An adapter that allows you to push to a networked peripheral instead
+ */
+@Asynchronous
+public class AdapterNetworkedInventory implements IPeripheralAdapter {
+	private static final int ANY_SLOT = -1;
+
+	@Override
+	public Class<?> getTargetClass() {
+		return IInventory.class;
+	}
+
+	@Override
+	public String getSourceId() {
+		return "inventory-world-networked";
+	}
+
+	private static void checkSlotId(IInventory inventory, int slot, String name) {
+		if (slot != ANY_SLOT) Preconditions.checkElementIndex(slot, inventory.getSizeInventory(), name + " slot id");
+	}
+
+	public static IInventory getInventory(INetworkAccess network, String name) {
+		Object object = CCTweaksAPI.instance().peripheralHelpers().getTarget(network.peripheralsByName().get(name));
+		if (object != null && object instanceof IInventory) return InventoryUtils.getInventory((IInventory) object);
+		return null;
+	}
+
+	public static final INetworkAccess network = null;
+
+	@Alias("pullItemIntoSlotRemote")
+	@ScriptCallable(returnTypes = ReturnType.NUMBER, description = "Pull an item from a slot in another inventory into a slot in this one. Returns the amount of items moved")
+	public int pullItemRemote(
+		IInventory target, @Env(INetworkedAdapter.ARG_NETWORK) INetworkAccess network,
+		@Arg(name = "remoteName", description = "The name of the remote inventory") String remote,
+		@Arg(name = "slot", description = "The slot in the OTHER inventory that you're pulling from") int fromSlot,
+		@Optionals @Arg(name = "maxAmount", description = "The maximum amount of items you want to pull") Integer maxAmount,
+		@Arg(name = "intoSlot", description = "The slot in the current inventory that you want to pull into") Integer intoSlot
+	) {
+		Preconditions.checkNotNull(network, "Cannot find the network");
+
+		final IInventory otherInventory = Preconditions.checkNotNull(getInventory(network, remote), "Other inventory not found");
+		final IInventory thisInventory = Preconditions.checkNotNull(InventoryUtils.getInventory(target), "Inventory not found");
+
+		if (otherInventory == target) return 0;
+		if (maxAmount == null) maxAmount = 64;
+		if (intoSlot == null) intoSlot = 0;
+
+		fromSlot -= 1;
+		intoSlot -= 1;
+
+		checkSlotId(otherInventory, fromSlot, "input");
+		checkSlotId(thisInventory, intoSlot, "output");
+
+		final int amount = InventoryUtils.moveItemInto(otherInventory, fromSlot, thisInventory, intoSlot, maxAmount, ForgeDirection.UNKNOWN);
+		if (amount > 0) {
+			thisInventory.markDirty();
+			otherInventory.markDirty();
+		}
+
+		return amount;
+	}
+
+	@Alias("pushItemIntoSlotRemote")
+	@ScriptCallable(returnTypes = ReturnType.NUMBER, description = "Push an item from the current inventory into slot on the other one. Returns the amount of items moved")
+	public int pushItemRemote(
+		IInventory target, @Env(INetworkedAdapter.ARG_NETWORK) INetworkAccess network,
+		@Arg(name = "remoteName", description = "The name of the remote inventory") String remote,
+		@Arg(name = "slot", description = "The slot in the current inventory that you're pushing from") int fromSlot,
+		@Optionals @Arg(name = "maxAmount", description = "The maximum amount of items you want to push") Integer maxAmount,
+		@Arg(name = "intoSlot", description = "The slot in the other inventory that you want to push into") Integer intoSlot
+	) {
+		Preconditions.checkNotNull(network, "Cannot find the network");
+
+		final IInventory otherInventory = getInventory(network, remote);
+		Preconditions.checkNotNull(otherInventory, "Other inventory not found");
+		final IInventory thisInventory = InventoryUtils.getInventory(target);
+
+		if (otherInventory == target) return 0;
+		if (maxAmount == null) maxAmount = 64;
+		if (intoSlot == null) intoSlot = 0;
+
+		fromSlot -= 1;
+		intoSlot -= 1;
+
+		checkSlotId(thisInventory, fromSlot, "input");
+		checkSlotId(otherInventory, intoSlot, "output");
+
+		int amount = InventoryUtils.moveItemInto(thisInventory, fromSlot, otherInventory, intoSlot, maxAmount, ForgeDirection.UNKNOWN);
+		if (amount > 0) {
+			thisInventory.markDirty();
+			otherInventory.markDirty();
+		}
+
+		return amount;
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/integration/openperipheral/AdapterNetworkedInventory.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/openperipheral/AdapterNetworkedInventory.java
@@ -8,7 +8,7 @@ import openperipheral.api.adapter.IPeripheralAdapter;
 import openperipheral.api.adapter.method.*;
 import org.squiddev.cctweaks.api.CCTweaksAPI;
 import org.squiddev.cctweaks.api.network.INetworkAccess;
-import org.squiddev.cctweaks.api.peripheral.INetworkedAdapter;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralEnvironments;
 import org.squiddev.cctweaks.core.utils.InventoryUtils;
 
 /**
@@ -43,7 +43,7 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 	@Alias("pullItemIntoSlotRemote")
 	@ScriptCallable(returnTypes = ReturnType.NUMBER, description = "Pull an item from a slot in another inventory into a slot in this one. Returns the amount of items moved")
 	public int pullItemRemote(
-		IInventory target, @Env(INetworkedAdapter.ARG_NETWORK) INetworkAccess network,
+		IInventory target, @Env(IPeripheralEnvironments.ARG_NETWORK) INetworkAccess network,
 		@Arg(name = "remoteName", description = "The name of the remote inventory") String remote,
 		@Arg(name = "slot", description = "The slot in the OTHER inventory that you're pulling from") int fromSlot,
 		@Optionals @Arg(name = "maxAmount", description = "The maximum amount of items you want to pull") Integer maxAmount,
@@ -76,7 +76,7 @@ public class AdapterNetworkedInventory implements IPeripheralAdapter {
 	@Alias("pushItemIntoSlotRemote")
 	@ScriptCallable(returnTypes = ReturnType.NUMBER, description = "Push an item from the current inventory into slot on the other one. Returns the amount of items moved")
 	public int pushItemRemote(
-		IInventory target, @Env(INetworkedAdapter.ARG_NETWORK) INetworkAccess network,
+		IInventory target, @Env(IPeripheralEnvironments.ARG_NETWORK) INetworkAccess network,
 		@Arg(name = "remoteName", description = "The name of the remote inventory") String remote,
 		@Arg(name = "slot", description = "The slot in the current inventory that you're pushing from") int fromSlot,
 		@Optionals @Arg(name = "maxAmount", description = "The maximum amount of items you want to push") Integer maxAmount,

--- a/src/main/java/org/squiddev/cctweaks/integration/openperipheral/OpenPeripheralIntegration.java
+++ b/src/main/java/org/squiddev/cctweaks/integration/openperipheral/OpenPeripheralIntegration.java
@@ -1,0 +1,25 @@
+package org.squiddev.cctweaks.integration.openperipheral;
+
+import openperipheral.api.ApiAccess;
+import openperipheral.api.adapter.IPeripheralAdapterRegistry;
+import org.squiddev.cctweaks.core.utils.DebugLogger;
+import org.squiddev.cctweaks.integration.APIIntegration;
+
+/**
+ * OpenPeripheral integration
+ */
+public class OpenPeripheralIntegration extends APIIntegration {
+	public OpenPeripheralIntegration() {
+		super("OpenPeripheralApi");
+	}
+
+	@Override
+	public void postInit() {
+		if (ApiAccess.isApiPresent(IPeripheralAdapterRegistry.class)) {
+			DebugLogger.debug("Registering custom AdapterNetworkedInventory");
+			ApiAccess.getApi(IPeripheralAdapterRegistry.class).register(new AdapterNetworkedInventory());
+		} else {
+			DebugLogger.error("Cannot register AdapterNetworkedInventory");
+		}
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/items/ItemBase.java
+++ b/src/main/java/org/squiddev/cctweaks/items/ItemBase.java
@@ -43,4 +43,8 @@ public abstract class ItemBase extends Item implements IModule {
 	@Override
 	public void init() {
 	}
+
+	@Override
+	public void postInit() {
+	}
 }

--- a/src/main/java/org/squiddev/cctweaks/turtle/TurtleUpgradeWirelessBridge.java
+++ b/src/main/java/org/squiddev/cctweaks/turtle/TurtleUpgradeWirelessBridge.java
@@ -23,7 +23,7 @@ import org.squiddev.cctweaks.core.Config;
 import org.squiddev.cctweaks.core.network.bridge.NetworkBinding;
 import org.squiddev.cctweaks.core.network.modem.BasicModem;
 import org.squiddev.cctweaks.core.network.modem.BasicModemPeripheral;
-import org.squiddev.cctweaks.core.registry.IModule;
+import org.squiddev.cctweaks.core.registry.Module;
 import org.squiddev.cctweaks.core.registry.Registry;
 
 import java.io.File;
@@ -33,7 +33,7 @@ import java.util.Map;
 /**
  * Turtle upgrade for the {@link TileNetworkedWirelessBridge} tile
  */
-public class TurtleUpgradeWirelessBridge implements ITurtleUpgrade, IModule {
+public class TurtleUpgradeWirelessBridge extends Module implements ITurtleUpgrade {
 	@Override
 	public int getUpgradeID() {
 		return Config.config.turtleWirelessBridgeId;
@@ -93,10 +93,6 @@ public class TurtleUpgradeWirelessBridge implements ITurtleUpgrade, IModule {
 	@Override
 	public boolean canLoad() {
 		return Config.config.turtleWirelessBridgeId > -1;
-	}
-
-	@Override
-	public void preInit() {
 	}
 
 	@Override

--- a/src/test/java/org/squiddev/cctweaks/core/peripheral/BasePeripheral.java
+++ b/src/test/java/org/squiddev/cctweaks/core/peripheral/BasePeripheral.java
@@ -1,0 +1,39 @@
+package org.squiddev.cctweaks.core.peripheral;
+
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import dan200.computercraft.api.peripheral.IPeripheral;
+
+/**
+ * A basic peripheral that does nothing
+ */
+public class BasePeripheral implements IPeripheral {
+	@Override
+	public String getType() {
+		return null;
+	}
+
+	@Override
+	public String[] getMethodNames() {
+		return null;
+	}
+
+	@Override
+	public Object[] callMethod(IComputerAccess computer, ILuaContext context, int index, Object[] args) throws LuaException, InterruptedException {
+		return null;
+	}
+
+	@Override
+	public void attach(IComputerAccess computer) {
+	}
+
+	@Override
+	public void detach(IComputerAccess computer) {
+	}
+
+	@Override
+	public boolean equals(IPeripheral peripheral) {
+		return peripheral == this;
+	}
+}

--- a/src/test/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpersTest.java
+++ b/src/test/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpersTest.java
@@ -2,6 +2,8 @@ package org.squiddev.cctweaks.core.peripheral;
 
 import dan200.computercraft.api.peripheral.IPeripheral;
 import org.junit.Test;
+import org.squiddev.cctweaks.api.CCTweaksAPI;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralHelpers;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralProxy;
 import org.squiddev.cctweaks.api.peripheral.IPeripheralTargeted;
 
@@ -11,7 +13,7 @@ import static org.junit.Assert.assertEquals;
  * Some tests for {@link PeripheralHelpers}
  */
 public class PeripheralHelpersTest {
-	public static final PeripheralHelpers helpers = new PeripheralHelpers();
+	public static final IPeripheralHelpers helpers = CCTweaksAPI.instance().peripheralHelpers();
 
 	@Test
 	public void testGetBasePeripheral() throws Exception {

--- a/src/test/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpersTest.java
+++ b/src/test/java/org/squiddev/cctweaks/core/peripheral/PeripheralHelpersTest.java
@@ -1,0 +1,100 @@
+package org.squiddev.cctweaks.core.peripheral;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import org.junit.Test;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralProxy;
+import org.squiddev.cctweaks.api.peripheral.IPeripheralTargeted;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Some tests for {@link PeripheralHelpers}
+ */
+public class PeripheralHelpersTest {
+	public static final PeripheralHelpers helpers = new PeripheralHelpers();
+
+	@Test
+	public void testGetBasePeripheral() throws Exception {
+		BasePeripheral base = new BasePeripheral();
+		Proxy empty = new Proxy(null);
+
+
+		assertProxy("Nested: 0", base, base);
+		assertProxy("Nested: 3", base, new Proxy(new Proxy(new Proxy(base))));
+
+		assertProxy("Null getBasePeripheral", empty, new Proxy(new Proxy(empty)));
+	}
+
+	@Test
+	public void testGetTarget() throws Exception {
+		IPeripheral base = new BasePeripheral();
+		Object target = new Object();
+		Targeted empty = new Targeted(null);
+
+		assertTarget("Straight run", base, base);
+		assertTarget("Target", target, new Targeted(target));
+
+		assertTarget("Proxy", base, new Proxy(new Proxy(base)));
+		assertTarget("Target and proxy", target, new Proxy(new Proxy(new Targeted(target))));
+
+		assertTarget("Prefer Target", target, new TargetProxy(
+			target,
+			new Proxy(new Targeted(target))
+		));
+
+		assertTarget("Return proxy on null target", target, new TargetProxy(
+			null,
+			new Proxy(new Targeted(target))
+		));
+
+		assertTarget("Return parent on null target", empty, new Proxy(new Proxy(empty)));
+	}
+
+	public static void assertProxy(String message, IPeripheral target, IPeripheral start) {
+		assertEquals(message, target, helpers.getBasePeripheral(start));
+	}
+
+	public static void assertTarget(String message, Object target, IPeripheral start) {
+		assertEquals(message, target, helpers.getTarget(start));
+	}
+
+	public static class Targeted extends BasePeripheral implements IPeripheralTargeted {
+		public final Object target;
+
+		public Targeted(Object target) {
+			this.target = target;
+		}
+
+		@Override
+		public Object getTarget() {
+			return target;
+		}
+	}
+
+	public static class Proxy extends BasePeripheral implements IPeripheralProxy {
+		public final IPeripheral base;
+
+		public Proxy(IPeripheral base) {
+			this.base = base;
+		}
+
+		@Override
+		public IPeripheral getBasePeripheral() {
+			return base;
+		}
+	}
+
+	public static class TargetProxy extends Targeted implements IPeripheralProxy {
+		public final IPeripheral base;
+
+		public TargetProxy(Object target, IPeripheral base) {
+			super(target);
+			this.base = base;
+		}
+
+		@Override
+		public IPeripheral getBasePeripheral() {
+			return base;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #26.

 - Adds `INetworkedPeripheral` support for OpenPeripheral.
 - Adds `IPeripheralProxy` and `ITargetedPeripheral` functions.
 - Adds `pushToRemote` and `pullFromRemote` methods - though I'll probably add a config option for that later on. I'm going to need to add lots of config options for various things.

You have no idea how much a laughed manically once I got the networked inventory methods working.

I'm also going to have a look so see if it possible to do some of this without ASM.